### PR TITLE
Adds lazy to implicit Encoder vals

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ it will be turned into:
 
 ```scala
 trait CirceCodecs extends SttpCirceApi {
-  implicit val personDecoder: Decoder[Person] =
+  implicit lazy val personDecoder: Decoder[Person] =
     Decoder.forProduct2("name", "age")(Person.apply)
-  implicit val personEncoder: Encoder[Person] =
+  implicit lazy val personEncoder: Encoder[Person] =
     Encoder.forProduct2("name", "age")(p => (p.name, p.age))
 }
 object CirceCodecs extends CirceCodecs
@@ -160,7 +160,7 @@ case class Person(name: String, age: Int) extends Entity()
 trait CirceCodecs extends SttpCirceApi {
   // codecs for Person and Organization omitted for readability
 
-  implicit val entityDecoder: Decoder[Entity] = new Decoder[Entity]() {
+  implicit lazy val entityDecoder: Decoder[Entity] = new Decoder[Entity]() {
     override def apply(c: HCursor): Result[Entity] = c
       .downField("name")
       .as[String]
@@ -171,7 +171,7 @@ trait CirceCodecs extends SttpCirceApi {
           Left(DecodingFailure("Unexpected value for coproduct:" + other, Nil))
       })
   }
-  implicit val entityEncoder: Encoder[Entity] = new Encoder[Entity]() {
+  implicit lazy val entityEncoder: Encoder[Entity] = new Encoder[Entity]() {
     override def apply(entity: Entity): Json = entity match {
       case person: Person => Encoder[Person].apply(person)
       case organization: Organization =>
@@ -295,7 +295,7 @@ components:
 
 ```scala
 trait CirceCodecs extends SttpCirceApi {
-  implicit val personDecoder: Decoder[Person] = new Decoder[Person]() {
+  implicit lazy val personDecoder: Decoder[Person] = new Decoder[Person]() {
     override def apply(c: HCursor): Result[Person] =
       for {
         name <- c.downField("name").as[String]
@@ -307,7 +307,7 @@ trait CirceCodecs extends SttpCirceApi {
         additionalProperties.filterKeys(_ != "name").filterKeys(_ != "age")
       )
   }
-  implicit val personEncoder: Encoder[Person] = new Encoder[Person]() {
+  implicit lazy val personEncoder: Encoder[Person] = new Encoder[Person]() {
     override def apply(person: Person): Json = Encoder
       .forProduct2[Person, String, Int]("name", "age")(p => (p.name, p.age))
       .apply(person)

--- a/core/src/main/scala/io/github/ghostbuster91/sttp/client3/json/circe/CirceCoproductCodecGenerator.scala
+++ b/core/src/main/scala/io/github/ghostbuster91/sttp/client3/json/circe/CirceCoproductCodecGenerator.scala
@@ -25,7 +25,7 @@ private[circe] class CirceCoproductCodecGenerator() {
         } yield {
           val cases = encoderCasesWithMapping(discriminator)
           val encoderInit = init"${t"$encoderTpe[$coproductType]"}()"
-          q"""implicit val $encoderName: $encoderTpe[$coproductType] = new $encoderInit {
+          q"""implicit lazy val $encoderName: $encoderTpe[$coproductType] = new $encoderInit {
             override def apply(${coproduct.toVar}: $coproductType): $jsonTpe = 
               ${coproduct.toVar} match {
                 ..case $cases
@@ -39,7 +39,7 @@ private[circe] class CirceCoproductCodecGenerator() {
         } yield {
           val cases = encoderCases(coproduct)
           val encoderInit = init"${t"$encoderTpe[$coproductType]"}()"
-          q"""implicit val $encoderName: $encoderTpe[$coproductType] = Encoder.instance {
+          q"""implicit lazy val $encoderName: $encoderTpe[$coproductType] = Encoder.instance {
                 ..case $cases
             }
             """
@@ -65,7 +65,7 @@ private[circe] class CirceCoproductCodecGenerator() {
             case Discriminator.EnumDsc(_, enum, _) => enum.typeName
           }
           val decoderInit = init"${t"$decoderTpe[$coproductType]"}()"
-          q"""implicit val $decoderName: $decoderTpe[$coproductType] = new $decoderInit {
+          q"""implicit lazy val $decoderName: $decoderTpe[$coproductType] = new $decoderInit {
             override def apply(c: $hCursorTpe): $resultTpe[$coproductType] =
               c.downField(${discriminator.fieldName}).as[$dscType].flatMap {
                 ..case $cases
@@ -75,7 +75,7 @@ private[circe] class CirceCoproductCodecGenerator() {
       case _ =>
         for {
           decoderTpe <- CirceTypeProvider.DecoderTpe
-        } yield q"""implicit val $decoderName: $decoderTpe[$coproductType] = List[$decoderTpe[$coproductType]](..${decoderCases(
+        } yield q"""implicit lazy val $decoderName: $decoderTpe[$coproductType] = List[$decoderTpe[$coproductType]](..${decoderCases(
           coproduct
         )}).reduceLeft(_ or _)"""
     }

--- a/core/src/main/scala/io/github/ghostbuster91/sttp/client3/json/circe/CirceEnumCodecGenerator.scala
+++ b/core/src/main/scala/io/github/ghostbuster91/sttp/client3/json/circe/CirceEnumCodecGenerator.scala
@@ -20,7 +20,7 @@ private[circe] object CirceEnumCodecGenerator {
         val encoderName = enum.asPrefix("Encoder")
         val cases = encoderCases(enum)
         q"""
-          implicit val $encoderName: $encoderTpe[${enum.typeName}]  = ${baseEncoder(
+          implicit lazy val $encoderName: $encoderTpe[${enum.typeName}]  = ${baseEncoder(
           enum
         )}.contramap {
               ..case $cases
@@ -34,7 +34,7 @@ private[circe] object CirceEnumCodecGenerator {
         val cases = decoderCases(enum)
         val decoderName = enum.asPrefix("Decoder")
         q"""
-          implicit val $decoderName: $decoderTpe[${enum.typeName}]  = ${baseDecoder(
+          implicit lazy val $decoderName: $decoderTpe[${enum.typeName}]  = ${baseDecoder(
           enum
         )}.emap {
               ..case $cases

--- a/core/src/main/scala/io/github/ghostbuster91/sttp/client3/json/circe/CirceOpenProductCodecGenerator.scala
+++ b/core/src/main/scala/io/github/ghostbuster91/sttp/client3/json/circe/CirceOpenProductCodecGenerator.scala
@@ -27,7 +27,7 @@ private[circe] class CirceOpenProductCodecGenerator {
       val encodedVarName = openProduct.name.toParam.term
       val encoderInit = init"${t"$encoderTpe[$resultClassType]"}()"
       q"""
-    implicit val $encoderName: $encoderTpe[$resultClassType] = 
+    implicit lazy val $encoderName: $encoderTpe[$resultClassType] =
       new $encoderInit {
         override def apply($encodedVarName: $resultClassType): $jsonTpe =
          ${baseEncoderApplication(openProduct)}
@@ -58,7 +58,7 @@ private[circe] class CirceOpenProductCodecGenerator {
       val resultClassType = openProduct.name.typeName
       val decoderInit = init"${t"$decoderTpe[$resultClassType]"}()"
       val decoderName = p"${openProduct.name.toParam.asPrefix("Decoder")}"
-      q"""implicit val $decoderName: $decoderTpe[$resultClassType] = 
+      q"""implicit lazy val $decoderName: $decoderTpe[$resultClassType] =
           new $decoderInit {
             override def apply(c: $hCursor): $decoderRes[$resultClassType] = 
               ${decoderBody(openProduct)}

--- a/core/src/main/scala/io/github/ghostbuster91/sttp/client3/json/circe/CirceProductCodecGenerator.scala
+++ b/core/src/main/scala/io/github/ghostbuster91/sttp/client3/json/circe/CirceProductCodecGenerator.scala
@@ -26,7 +26,7 @@ class CirceProductCodecGenerator {
           )
         case head :: Nil =>
           val propNames = head.paramName
-          q"""implicit val $encoderName: $encoderTpe[$resultClassType] = 
+          q"""implicit lazy val $encoderName: $encoderTpe[$resultClassType] =
                 Encoder.forProduct1(${Lit.String(
             propNames.v
           )})(p => p.${propNames.term})"""
@@ -34,7 +34,7 @@ class CirceProductCodecGenerator {
           val productEncoder = Term.Name(s"forProduct${props.size}")
           val propNames = props.map(_.paramName)
           val extractors = propNames.map(p => q"p.${p.term}")
-          q"""implicit val $encoderName: $encoderTpe[$resultClassType] = 
+          q"""implicit lazy val $encoderName: $encoderTpe[$resultClassType] =
                 Encoder.$productEncoder(..${propNames.map(p =>
             Lit.String(p.v)
           )})(p => (..$extractors))"""
@@ -48,7 +48,7 @@ class CirceProductCodecGenerator {
       val productDecoder = Term.Name(s"forProduct${product.properties.size}")
       val productElements =
         product.properties.map(p => Lit.String(p.paramName.v))
-      q"""implicit val $decoderName: $decoderTpe[$resultClassType] = 
+      q"""implicit lazy val $decoderName: $decoderTpe[$resultClassType] =
                 Decoder.$productDecoder(..$productElements)(${product.name.term}.apply)"""
     }
 }

--- a/core/src/test/resources/api/coproduct/all_of/multiple_parents.scala
+++ b/core/src/test/resources/api/coproduct/all_of/multiple_parents.scala
@@ -7,22 +7,22 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val dogDecoder: Decoder[Dog] =
+  implicit lazy val dogDecoder: Decoder[Dog] =
     Decoder.forProduct3("className", "color", "breed")(Dog.apply)
-  implicit val dogEncoder: Encoder[Dog] =
+  implicit lazy val dogEncoder: Encoder[Dog] =
     Encoder.forProduct3("className", "color", "breed")(p =>
       (p.className, p.color, p.breed)
     )
-  implicit val animalDecoder: Decoder[Animal] = List[Decoder[Animal]](
+  implicit lazy val animalDecoder: Decoder[Animal] = List[Decoder[Animal]](
     Decoder[Dog].asInstanceOf[Decoder[Animal]]
   ).reduceLeft(_ or _)
-  implicit val animalEncoder: Encoder[Animal] = Encoder.instance {
+  implicit lazy val animalEncoder: Encoder[Animal] = Encoder.instance {
     case dog: Dog => Encoder[Dog].apply(dog)
   }
-  implicit val breedAbleDecoder: Decoder[BreedAble] = List[Decoder[BreedAble]](
+  implicit lazy val breedAbleDecoder: Decoder[BreedAble] = List[Decoder[BreedAble]](
     Decoder[Dog].asInstanceOf[Decoder[BreedAble]]
   ).reduceLeft(_ or _)
-  implicit val breedAbleEncoder: Encoder[BreedAble] = Encoder.instance {
+  implicit lazy val breedAbleEncoder: Encoder[BreedAble] = Encoder.instance {
     case dog: Dog => Encoder[Dog].apply(dog)
   }
 }

--- a/core/src/test/resources/api/coproduct/all_of/multiple_siblings.scala
+++ b/core/src/test/resources/api/coproduct/all_of/multiple_siblings.scala
@@ -7,31 +7,31 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val dogDecoder: Decoder[Dog] =
+  implicit lazy val dogDecoder: Decoder[Dog] =
     Decoder.forProduct3("className", "color", "breed")(Dog.apply)
-  implicit val dogEncoder: Encoder[Dog] =
+  implicit lazy val dogEncoder: Encoder[Dog] =
     Encoder.forProduct3("className", "color", "breed")(p =>
       (p.className, p.color, p.breed)
     )
-  implicit val catDecoder: Decoder[Cat] =
+  implicit lazy val catDecoder: Decoder[Cat] =
     Decoder.forProduct3("className", "color", "breed")(Cat.apply)
-  implicit val catEncoder: Encoder[Cat] =
+  implicit lazy val catEncoder: Encoder[Cat] =
     Encoder.forProduct3("className", "color", "breed")(p =>
       (p.className, p.color, p.breed)
     )
-  implicit val animalDecoder: Decoder[Animal] = List[Decoder[Animal]](
+  implicit lazy val animalDecoder: Decoder[Animal] = List[Decoder[Animal]](
     Decoder[Dog].asInstanceOf[Decoder[Animal]],
     Decoder[Cat].asInstanceOf[Decoder[Animal]]
   ).reduceLeft(_ or _)
-  implicit val animalEncoder: Encoder[Animal] = Encoder.instance {
+  implicit lazy val animalEncoder: Encoder[Animal] = Encoder.instance {
     case dog: Dog => Encoder[Dog].apply(dog)
     case cat: Cat => Encoder[Cat].apply(cat)
   }
-  implicit val breedAbleDecoder: Decoder[BreedAble] = List[Decoder[BreedAble]](
+  implicit lazy val breedAbleDecoder: Decoder[BreedAble] = List[Decoder[BreedAble]](
     Decoder[Dog].asInstanceOf[Decoder[BreedAble]],
     Decoder[Cat].asInstanceOf[Decoder[BreedAble]]
   ).reduceLeft(_ or _)
-  implicit val breedAbleEncoder: Encoder[BreedAble] = Encoder.instance {
+  implicit lazy val breedAbleEncoder: Encoder[BreedAble] = Encoder.instance {
     case dog: Dog => Encoder[Dog].apply(dog)
     case cat: Cat => Encoder[Cat].apply(cat)
   }

--- a/core/src/test/resources/api/coproduct/all_of/simple.scala
+++ b/core/src/test/resources/api/coproduct/all_of/simple.scala
@@ -7,16 +7,16 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val dogDecoder: Decoder[Dog] =
+  implicit lazy val dogDecoder: Decoder[Dog] =
     Decoder.forProduct3("className", "color", "breed")(Dog.apply)
-  implicit val dogEncoder: Encoder[Dog] =
+  implicit lazy val dogEncoder: Encoder[Dog] =
     Encoder.forProduct3("className", "color", "breed")(p =>
       (p.className, p.color, p.breed)
     )
-  implicit val animalDecoder: Decoder[Animal] = List[Decoder[Animal]](
+  implicit lazy val animalDecoder: Decoder[Animal] = List[Decoder[Animal]](
     Decoder[Dog].asInstanceOf[Decoder[Animal]]
   ).reduceLeft(_ or _)
-  implicit val animalEncoder: Encoder[Animal] = Encoder.instance {
+  implicit lazy val animalEncoder: Encoder[Animal] = Encoder.instance {
     case dog: Dog => Encoder[Dog].apply(dog)
   }
 }

--- a/core/src/test/resources/api/coproduct/one_of/discriminator_enum.scala
+++ b/core/src/test/resources/api/coproduct/one_of/discriminator_enum.scala
@@ -7,7 +7,7 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val personNameDecoder: Decoder[PersonName] =
+  implicit lazy val personNameDecoder: Decoder[PersonName] =
     Decoder.decodeString.emap {
       case "bob" =>
         Right(PersonName.Bob)
@@ -16,24 +16,24 @@ trait CirceCodecs extends SttpCirceApi {
       case other =>
         Left("Unexpected value for enum:" + other)
     }
-  implicit val personNameEncoder: Encoder[PersonName] =
+  implicit lazy val personNameEncoder: Encoder[PersonName] =
     Encoder.encodeString.contramap {
       case PersonName.Bob   => "bob"
       case PersonName.Alice => "alice"
     }
-  implicit val personDecoder: Decoder[Person] =
+  implicit lazy val personDecoder: Decoder[Person] =
     Decoder.forProduct2("name", "age")(Person.apply)
-  implicit val personEncoder: Encoder[Person] =
+  implicit lazy val personEncoder: Encoder[Person] =
     Encoder.forProduct2("name", "age")(p => (p.name, p.age))
-  implicit val organizationDecoder: Decoder[Organization] =
+  implicit lazy val organizationDecoder: Decoder[Organization] =
     Decoder.forProduct1("name")(Organization.apply)
-  implicit val organizationEncoder: Encoder[Organization] =
+  implicit lazy val organizationEncoder: Encoder[Organization] =
     Encoder.forProduct1("name")(p => p.name)
-  implicit val entityDecoder: Decoder[Entity] = List[Decoder[Entity]](
+  implicit lazy val entityDecoder: Decoder[Entity] = List[Decoder[Entity]](
     Decoder[Person].asInstanceOf[Decoder[Entity]],
     Decoder[Organization].asInstanceOf[Decoder[Entity]]
   ).reduceLeft(_ or _)
-  implicit val entityEncoder: Encoder[Entity] = Encoder.instance {
+  implicit lazy val entityEncoder: Encoder[Entity] = Encoder.instance {
     case person: Person             => Encoder[Person].apply(person)
     case organization: Organization => Encoder[Organization].apply(organization)
   }

--- a/core/src/test/resources/api/coproduct/one_of/discriminator_with_enum_mapping.scala
+++ b/core/src/test/resources/api/coproduct/one_of/discriminator_with_enum_mapping.scala
@@ -11,7 +11,7 @@ import _root_.io.circe.Decoder.Result
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val personNameDecoder: Decoder[PersonName] =
+  implicit lazy val personNameDecoder: Decoder[PersonName] =
     Decoder.decodeString.emap {
       case "bob" =>
         Right(PersonName.Bob)
@@ -20,20 +20,20 @@ trait CirceCodecs extends SttpCirceApi {
       case other =>
         Left("Unexpected value for enum:" + other)
     }
-  implicit val personNameEncoder: Encoder[PersonName] =
+  implicit lazy val personNameEncoder: Encoder[PersonName] =
     Encoder.encodeString.contramap {
       case PersonName.Bob   => "bob"
       case PersonName.Alice => "alice"
     }
-  implicit val personDecoder: Decoder[Person] =
+  implicit lazy val personDecoder: Decoder[Person] =
     Decoder.forProduct2("name", "age")(Person.apply)
-  implicit val personEncoder: Encoder[Person] =
+  implicit lazy val personEncoder: Encoder[Person] =
     Encoder.forProduct2("name", "age")(p => (p.name, p.age))
-  implicit val organizationDecoder: Decoder[Organization] =
+  implicit lazy val organizationDecoder: Decoder[Organization] =
     Decoder.forProduct1("name")(Organization.apply)
-  implicit val organizationEncoder: Encoder[Organization] =
+  implicit lazy val organizationEncoder: Encoder[Organization] =
     Encoder.forProduct1("name")(p => p.name)
-  implicit val entityDecoder: Decoder[Entity] = new Decoder[Entity]() {
+  implicit lazy val entityDecoder: Decoder[Entity] = new Decoder[Entity]() {
     override def apply(c: HCursor): Result[Entity] = c
       .downField("name")
       .as[PersonName]
@@ -46,7 +46,7 @@ trait CirceCodecs extends SttpCirceApi {
           Left(DecodingFailure("Unexpected value for coproduct:" + other, Nil))
       }
   }
-  implicit val entityEncoder: Encoder[Entity] = new Encoder[Entity]() {
+  implicit lazy val entityEncoder: Encoder[Entity] = new Encoder[Entity]() {
     override def apply(entity: Entity): Json = entity match {
       case person: Person =>
         Encoder[Person].apply(person)

--- a/core/src/test/resources/api/coproduct/one_of/discriminator_with_mapping.scala
+++ b/core/src/test/resources/api/coproduct/one_of/discriminator_with_mapping.scala
@@ -11,15 +11,15 @@ import _root_.io.circe.Decoder.Result
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val personDecoder: Decoder[Person] =
+  implicit lazy val personDecoder: Decoder[Person] =
     Decoder.forProduct2("name", "age")(Person.apply)
-  implicit val personEncoder: Encoder[Person] =
+  implicit lazy val personEncoder: Encoder[Person] =
     Encoder.forProduct2("name", "age")(p => (p.name, p.age))
-  implicit val organizationDecoder: Decoder[Organization] =
+  implicit lazy val organizationDecoder: Decoder[Organization] =
     Decoder.forProduct1("name")(Organization.apply)
-  implicit val organizationEncoder: Encoder[Organization] =
+  implicit lazy val organizationEncoder: Encoder[Organization] =
     Encoder.forProduct1("name")(p => p.name)
-  implicit val entityDecoder: Decoder[Entity] = new Decoder[Entity]() {
+  implicit lazy val entityDecoder: Decoder[Entity] = new Decoder[Entity]() {
     override def apply(c: HCursor): Result[Entity] = c
       .downField("name")
       .as[String]
@@ -32,7 +32,7 @@ trait CirceCodecs extends SttpCirceApi {
           Left(DecodingFailure("Unexpected value for coproduct:" + other, Nil))
       }
   }
-  implicit val entityEncoder: Encoder[Entity] = new Encoder[Entity]() {
+  implicit lazy val entityEncoder: Encoder[Entity] = new Encoder[Entity]() {
     override def apply(entity: Entity): Json = entity match {
       case person: Person =>
         Encoder[Person].apply(person)

--- a/core/src/test/resources/api/coproduct/one_of/int_discriminator.scala
+++ b/core/src/test/resources/api/coproduct/one_of/int_discriminator.scala
@@ -7,19 +7,19 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val personDecoder: Decoder[Person] =
+  implicit lazy val personDecoder: Decoder[Person] =
     Decoder.forProduct2("name", "age")(Person.apply)
-  implicit val personEncoder: Encoder[Person] =
+  implicit lazy val personEncoder: Encoder[Person] =
     Encoder.forProduct2("name", "age")(p => (p.name, p.age))
-  implicit val organizationDecoder: Decoder[Organization] =
+  implicit lazy val organizationDecoder: Decoder[Organization] =
     Decoder.forProduct1("name")(Organization.apply)
-  implicit val organizationEncoder: Encoder[Organization] =
+  implicit lazy val organizationEncoder: Encoder[Organization] =
     Encoder.forProduct1("name")(p => p.name)
-  implicit val entityDecoder: Decoder[Entity] = List[Decoder[Entity]](
+  implicit lazy val entityDecoder: Decoder[Entity] = List[Decoder[Entity]](
     Decoder[Person].asInstanceOf[Decoder[Entity]],
     Decoder[Organization].asInstanceOf[Decoder[Entity]]
   ).reduceLeft(_ or _)
-  implicit val entityEncoder: Encoder[Entity] = Encoder.instance {
+  implicit lazy val entityEncoder: Encoder[Entity] = Encoder.instance {
     case person: Person             => Encoder[Person].apply(person)
     case organization: Organization => Encoder[Organization].apply(organization)
   }

--- a/core/src/test/resources/api/coproduct/one_of/multiple_parents.scala
+++ b/core/src/test/resources/api/coproduct/one_of/multiple_parents.scala
@@ -7,28 +7,28 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val organizationDecoder: Decoder[Organization] =
+  implicit lazy val organizationDecoder: Decoder[Organization] =
     Decoder.forProduct1("name")(Organization.apply)
-  implicit val organizationEncoder: Encoder[Organization] =
+  implicit lazy val organizationEncoder: Encoder[Organization] =
     Encoder.forProduct1("name")(p => p.name)
-  implicit val personDecoder: Decoder[Person] =
+  implicit lazy val personDecoder: Decoder[Person] =
     Decoder.forProduct2("name", "age")(Person.apply)
-  implicit val personEncoder: Encoder[Person] =
+  implicit lazy val personEncoder: Encoder[Person] =
     Encoder.forProduct2("name", "age")(p => (p.name, p.age))
-  implicit val doubledEntityDecoder: Decoder[DoubledEntity] =
+  implicit lazy val doubledEntityDecoder: Decoder[DoubledEntity] =
     List[Decoder[DoubledEntity]](
       Decoder[Organization].asInstanceOf[Decoder[DoubledEntity]],
       Decoder[Person].asInstanceOf[Decoder[DoubledEntity]]
     ).reduceLeft(_ or _)
-  implicit val doubledEntityEncoder: Encoder[DoubledEntity] = Encoder.instance {
+  implicit lazy val doubledEntityEncoder: Encoder[DoubledEntity] = Encoder.instance {
     case organization: Organization => Encoder[Organization].apply(organization)
     case person: Person             => Encoder[Person].apply(person)
   }
-  implicit val entityDecoder: Decoder[Entity] = List[Decoder[Entity]](
+  implicit lazy val entityDecoder: Decoder[Entity] = List[Decoder[Entity]](
     Decoder[Organization].asInstanceOf[Decoder[Entity]],
     Decoder[Person].asInstanceOf[Decoder[Entity]]
   ).reduceLeft(_ or _)
-  implicit val entityEncoder: Encoder[Entity] = Encoder.instance {
+  implicit lazy val entityEncoder: Encoder[Entity] = Encoder.instance {
     case organization: Organization => Encoder[Organization].apply(organization)
     case person: Person             => Encoder[Person].apply(person)
   }

--- a/core/src/test/resources/api/coproduct/one_of/simple.scala
+++ b/core/src/test/resources/api/coproduct/one_of/simple.scala
@@ -7,19 +7,19 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val organizationDecoder: Decoder[Organization] =
+  implicit lazy val organizationDecoder: Decoder[Organization] =
     Decoder.forProduct1("name")(Organization.apply)
-  implicit val organizationEncoder: Encoder[Organization] =
+  implicit lazy val organizationEncoder: Encoder[Organization] =
     Encoder.forProduct1("name")(p => p.name)
-  implicit val personDecoder: Decoder[Person] =
+  implicit lazy val personDecoder: Decoder[Person] =
     Decoder.forProduct2("name", "age")(Person.apply)
-  implicit val personEncoder: Encoder[Person] =
+  implicit lazy val personEncoder: Encoder[Person] =
     Encoder.forProduct2("name", "age")(p => (p.name, p.age))
-  implicit val entityDecoder: Decoder[Entity] = List[Decoder[Entity]](
+  implicit lazy val entityDecoder: Decoder[Entity] = List[Decoder[Entity]](
     Decoder[Organization].asInstanceOf[Decoder[Entity]],
     Decoder[Person].asInstanceOf[Decoder[Entity]]
   ).reduceLeft(_ or _)
-  implicit val entityEncoder: Encoder[Entity] = Encoder.instance {
+  implicit lazy val entityEncoder: Encoder[Entity] = Encoder.instance {
     case organization: Organization => Encoder[Organization].apply(organization)
     case person: Person             => Encoder[Person].apply(person)
   }

--- a/core/src/test/resources/api/coproduct/one_of/string_discriminator.scala
+++ b/core/src/test/resources/api/coproduct/one_of/string_discriminator.scala
@@ -7,19 +7,19 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val personDecoder: Decoder[Person] =
+  implicit lazy val personDecoder: Decoder[Person] =
     Decoder.forProduct2("name", "age")(Person.apply)
-  implicit val personEncoder: Encoder[Person] =
+  implicit lazy val personEncoder: Encoder[Person] =
     Encoder.forProduct2("name", "age")(p => (p.name, p.age))
-  implicit val organizationDecoder: Decoder[Organization] =
+  implicit lazy val organizationDecoder: Decoder[Organization] =
     Decoder.forProduct1("name")(Organization.apply)
-  implicit val organizationEncoder: Encoder[Organization] =
+  implicit lazy val organizationEncoder: Encoder[Organization] =
     Encoder.forProduct1("name")(p => p.name)
-  implicit val entityDecoder: Decoder[Entity] = List[Decoder[Entity]](
+  implicit lazy val entityDecoder: Decoder[Entity] = List[Decoder[Entity]](
     Decoder[Person].asInstanceOf[Decoder[Entity]],
     Decoder[Organization].asInstanceOf[Decoder[Entity]]
   ).reduceLeft(_ or _)
-  implicit val entityEncoder: Encoder[Entity] = Encoder.instance {
+  implicit lazy val entityEncoder: Encoder[Entity] = Encoder.instance {
     case person: Person             => Encoder[Person].apply(person)
     case organization: Organization => Encoder[Organization].apply(organization)
   }

--- a/core/src/test/resources/api/enum/component_enum.scala
+++ b/core/src/test/resources/api/enum/component_enum.scala
@@ -7,7 +7,7 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val statusDecoder: Decoder[Status] =
+  implicit lazy val statusDecoder: Decoder[Status] =
     Decoder.decodeString.emap {
       case "happy" =>
         Right(Status.Happy)
@@ -16,15 +16,15 @@ trait CirceCodecs extends SttpCirceApi {
       case other =>
         Left("Unexpected value for enum:" + other)
     }
-  implicit val statusEncoder: Encoder[Status] =
+  implicit lazy val statusEncoder: Encoder[Status] =
     Encoder.encodeString.contramap {
       case Status.Happy   => "happy"
       case Status.Neutral => "neutral"
     }
 
-  implicit val personDecoder: Decoder[Person] =
+  implicit lazy val personDecoder: Decoder[Person] =
     Decoder.forProduct1("status")(Person.apply)
-  implicit val personEncoder: Encoder[Person] =
+  implicit lazy val personEncoder: Encoder[Person] =
     Encoder.forProduct1("status")(p => p.status)
 }
 object CirceCodecs extends CirceCodecs

--- a/core/src/test/resources/api/enum/duplicated_enum.scala
+++ b/core/src/test/resources/api/enum/duplicated_enum.scala
@@ -7,7 +7,7 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val status2Decoder: Decoder[Status2] = Decoder.decodeString.emap {
+  implicit lazy val status2Decoder: Decoder[Status2] = Decoder.decodeString.emap {
     case "new" =>
       Right(Status2.New)
     case "old" =>
@@ -15,12 +15,12 @@ trait CirceCodecs extends SttpCirceApi {
     case other =>
       Left("Unexpected value for enum:" + other)
   }
-  implicit val status2Encoder: Encoder[Status2] =
+  implicit lazy val status2Encoder: Encoder[Status2] =
     Encoder.encodeString.contramap {
       case Status2.New => "new"
       case Status2.Old => "old"
     }
-  implicit val statusDecoder: Decoder[Status] = Decoder.decodeString.emap {
+  implicit lazy val statusDecoder: Decoder[Status] = Decoder.decodeString.emap {
     case "happy" =>
       Right(Status.Happy)
     case "neutral" =>
@@ -28,22 +28,22 @@ trait CirceCodecs extends SttpCirceApi {
     case other =>
       Left("Unexpected value for enum:" + other)
   }
-  implicit val statusEncoder: Encoder[Status] =
+  implicit lazy val statusEncoder: Encoder[Status] =
     Encoder.encodeString.contramap {
       case Status.Happy   => "happy"
       case Status.Neutral => "neutral"
     }
-  implicit val person1Decoder: Decoder[Person1] =
+  implicit lazy val person1Decoder: Decoder[Person1] =
     Decoder.forProduct1("status")(Person1.apply)
-  implicit val person1Encoder: Encoder[Person1] =
+  implicit lazy val person1Encoder: Encoder[Person1] =
     Encoder.forProduct1("status")(p => p.status)
-  implicit val person2Decoder: Decoder[Person2] =
+  implicit lazy val person2Decoder: Decoder[Person2] =
     Decoder.forProduct1("status")(Person2.apply)
-  implicit val person2Encoder: Encoder[Person2] =
+  implicit lazy val person2Encoder: Encoder[Person2] =
     Encoder.forProduct1("status")(p => p.status)
-  implicit val coupleDecoder: Decoder[Couple] =
+  implicit lazy val coupleDecoder: Decoder[Couple] =
     Decoder.forProduct2("p1", "p2")(Couple.apply)
-  implicit val coupleEncoder: Encoder[Couple] =
+  implicit lazy val coupleEncoder: Encoder[Couple] =
     Encoder.forProduct2("p1", "p2")(p => (p.p1, p.p2))
 }
 object CirceCodecs extends CirceCodecs

--- a/core/src/test/resources/api/enum/duplicated_enum_usage.scala
+++ b/core/src/test/resources/api/enum/duplicated_enum_usage.scala
@@ -7,7 +7,7 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val statusDecoder: Decoder[Status] = Decoder.decodeString.emap {
+  implicit lazy val statusDecoder: Decoder[Status] = Decoder.decodeString.emap {
     case "happy" =>
       Right(Status.Happy)
     case "neutral" =>
@@ -15,17 +15,17 @@ trait CirceCodecs extends SttpCirceApi {
     case other =>
       Left("Unexpected value for enum:" + other)
   }
-  implicit val statusEncoder: Encoder[Status] = Encoder.encodeString.contramap {
+  implicit lazy val statusEncoder: Encoder[Status] = Encoder.encodeString.contramap {
     case Status.Happy   => "happy"
     case Status.Neutral => "neutral"
   }
-  implicit val coupleDecoder: Decoder[Couple] =
+  implicit lazy val coupleDecoder: Decoder[Couple] =
     Decoder.forProduct2("p1", "p2")(Couple.apply)
-  implicit val coupleEncoder: Encoder[Couple] =
+  implicit lazy val coupleEncoder: Encoder[Couple] =
     Encoder.forProduct2("p1", "p2")(p => (p.p1, p.p2))
-  implicit val personDecoder: Decoder[Person] =
+  implicit lazy val personDecoder: Decoder[Person] =
     Decoder.forProduct1("status")(Person.apply)
-  implicit val personEncoder: Encoder[Person] =
+  implicit lazy val personEncoder: Encoder[Person] =
     Encoder.forProduct1("status")(p => p.status)
 }
 object CirceCodecs extends CirceCodecs

--- a/core/src/test/resources/api/enum/int_enum.scala
+++ b/core/src/test/resources/api/enum/int_enum.scala
@@ -7,7 +7,7 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val statusDecoder: Decoder[Status] =
+  implicit lazy val statusDecoder: Decoder[Status] =
     Decoder.decodeInt.emap {
       case 1 =>
         Right(Status.`1`)
@@ -18,15 +18,15 @@ trait CirceCodecs extends SttpCirceApi {
       case other =>
         Left("Unexpected value for enum:" + other)
     }
-  implicit val statusEncoder: Encoder[Status] =
+  implicit lazy val statusEncoder: Encoder[Status] =
     Encoder.encodeInt.contramap {
       case Status.`1` => 1
       case Status.`2` => 2
       case Status.`3` => 3
     }
-  implicit val personDecoder: Decoder[Person] =
+  implicit lazy val personDecoder: Decoder[Person] =
     Decoder.forProduct1("status")(Person.apply)
-  implicit val personEncoder: Encoder[Person] =
+  implicit lazy val personEncoder: Encoder[Person] =
     Encoder.forProduct1("status")(p => p.status)
 }
 object CirceCodecs extends CirceCodecs

--- a/core/src/test/resources/api/enum/string_enum.scala
+++ b/core/src/test/resources/api/enum/string_enum.scala
@@ -6,7 +6,7 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val statusDecoder: Decoder[Status] = Decoder.decodeString.emap {
+  implicit lazy val statusDecoder: Decoder[Status] = Decoder.decodeString.emap {
     case "happy" =>
       Right(Status.Happy)
     case "neutral" =>
@@ -14,14 +14,14 @@ trait CirceCodecs extends SttpCirceApi {
     case other =>
       Left("Unexpected value for enum:" + other)
   }
-  implicit val statusEncoder: Encoder[Status] = Encoder.encodeString.contramap {
+  implicit lazy val statusEncoder: Encoder[Status] = Encoder.encodeString.contramap {
     case Status.Happy   => "happy"
     case Status.Neutral => "neutral"
   }
 
-  implicit val personDecoder: Decoder[Person] =
+  implicit lazy val personDecoder: Decoder[Person] =
     Decoder.forProduct1("status")(Person.apply)
-  implicit val personEncoder: Encoder[Person] =
+  implicit lazy val personEncoder: Encoder[Person] =
     Encoder.forProduct1("status")(p => p.status)
 }
 object CirceCodecs extends CirceCodecs

--- a/core/src/test/resources/api/errors/multiple_errors.scala
+++ b/core/src/test/resources/api/errors/multiple_errors.scala
@@ -8,21 +8,21 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val errorModelDecoder: Decoder[ErrorModel] =
+  implicit lazy val errorModelDecoder: Decoder[ErrorModel] =
     Decoder.forProduct1("msg")(ErrorModel.apply)
-  implicit val errorModelEncoder: Encoder[ErrorModel] =
+  implicit lazy val errorModelEncoder: Encoder[ErrorModel] =
     Encoder.forProduct1("msg")(p => p.msg)
-  implicit val errorModel2Decoder: Decoder[ErrorModel2] =
+  implicit lazy val errorModel2Decoder: Decoder[ErrorModel2] =
     Decoder.forProduct1("msg")(ErrorModel2.apply)
-  implicit val errorModel2Encoder: Encoder[ErrorModel2] =
+  implicit lazy val errorModel2Encoder: Encoder[ErrorModel2] =
     Encoder.forProduct1("msg")(p => p.msg)
-  implicit val updatePersonGenericErrorDecoder
+  implicit lazy val updatePersonGenericErrorDecoder
       : Decoder[UpdatePersonGenericError] =
     List[Decoder[UpdatePersonGenericError]](
       Decoder[ErrorModel].asInstanceOf[Decoder[UpdatePersonGenericError]],
       Decoder[ErrorModel2].asInstanceOf[Decoder[UpdatePersonGenericError]]
     ).reduceLeft(_ or _)
-  implicit val updatePersonGenericErrorEncoder
+  implicit lazy val updatePersonGenericErrorEncoder
       : Encoder[UpdatePersonGenericError] = Encoder.instance {
     case errorModel: ErrorModel =>
       Encoder[ErrorModel].apply(errorModel)

--- a/core/src/test/resources/api/errors/multiple_errors_with_parent.scala
+++ b/core/src/test/resources/api/errors/multiple_errors_with_parent.scala
@@ -8,19 +8,19 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val errorModelDecoder: Decoder[ErrorModel] =
+  implicit lazy val errorModelDecoder: Decoder[ErrorModel] =
     Decoder.forProduct1("msg")(ErrorModel.apply)
-  implicit val errorModelEncoder: Encoder[ErrorModel] =
+  implicit lazy val errorModelEncoder: Encoder[ErrorModel] =
     Encoder.forProduct1("msg")(p => p.msg)
-  implicit val errorModel2Decoder: Decoder[ErrorModel2] =
+  implicit lazy val errorModel2Decoder: Decoder[ErrorModel2] =
     Decoder.forProduct1("msg")(ErrorModel2.apply)
-  implicit val errorModel2Encoder: Encoder[ErrorModel2] =
+  implicit lazy val errorModel2Encoder: Encoder[ErrorModel2] =
     Encoder.forProduct1("msg")(p => p.msg)
-  implicit val entityDecoder: Decoder[Entity] = List[Decoder[Entity]](
+  implicit lazy val entityDecoder: Decoder[Entity] = List[Decoder[Entity]](
     Decoder[ErrorModel].asInstanceOf[Decoder[Entity]],
     Decoder[ErrorModel2].asInstanceOf[Decoder[Entity]]
   ).reduceLeft(_ or _)
-  implicit val entityEncoder: Encoder[Entity] = Encoder.instance {
+  implicit lazy val entityEncoder: Encoder[Entity] = Encoder.instance {
     case errorModel: ErrorModel =>
       Encoder[ErrorModel].apply(errorModel)
     case errorModel2: ErrorModel2 =>

--- a/core/src/test/resources/api/errors/product.scala
+++ b/core/src/test/resources/api/errors/product.scala
@@ -8,9 +8,9 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val errorModelDecoder: Decoder[ErrorModel] =
+  implicit lazy val errorModelDecoder: Decoder[ErrorModel] =
     Decoder.forProduct1("msg")(ErrorModel.apply)
-  implicit val errorModelEncoder: Encoder[ErrorModel] =
+  implicit lazy val errorModelEncoder: Encoder[ErrorModel] =
     Encoder.forProduct1("msg")(p => p.msg)
 }
 object CirceCodecs extends CirceCodecs

--- a/core/src/test/resources/api/get_inline_response_200.scala
+++ b/core/src/test/resources/api/get_inline_response_200.scala
@@ -7,9 +7,9 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val inlineResponse200Decoder: Decoder[InlineResponse200] =
+  implicit lazy val inlineResponse200Decoder: Decoder[InlineResponse200] =
     Decoder.forProduct1("status")(InlineResponse200.apply)
-  implicit val inlineResponse200Encoder: Encoder[InlineResponse200] =
+  implicit lazy val inlineResponse200Encoder: Encoder[InlineResponse200] =
     Encoder.forProduct1("status")(p => p.status)
 }
 object CirceCodecs extends CirceCodecs

--- a/core/src/test/resources/api/multiple_success/common_ancestor.scala
+++ b/core/src/test/resources/api/multiple_success/common_ancestor.scala
@@ -7,19 +7,19 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val personDecoder: Decoder[Person] =
+  implicit lazy val personDecoder: Decoder[Person] =
     Decoder.forProduct2("name", "age")(Person.apply)
-  implicit val personEncoder: Encoder[Person] =
+  implicit lazy val personEncoder: Encoder[Person] =
     Encoder.forProduct2("name", "age")(p => (p.name, p.age))
-  implicit val organizationDecoder: Decoder[Organization] =
+  implicit lazy val organizationDecoder: Decoder[Organization] =
     Decoder.forProduct1("name")(Organization.apply)
-  implicit val organizationEncoder: Encoder[Organization] =
+  implicit lazy val organizationEncoder: Encoder[Organization] =
     Encoder.forProduct1("name")(p => p.name)
-  implicit val entityDecoder: Decoder[Entity] = List[Decoder[Entity]](
+  implicit lazy val entityDecoder: Decoder[Entity] = List[Decoder[Entity]](
     Decoder[Person].asInstanceOf[Decoder[Entity]],
     Decoder[Organization].asInstanceOf[Decoder[Entity]]
   ).reduceLeft(_ or _)
-  implicit val entityEncoder: Encoder[Entity] = Encoder.instance {
+  implicit lazy val entityEncoder: Encoder[Entity] = Encoder.instance {
     case person: Person =>
       Encoder[Person].apply(person)
     case organization: Organization =>

--- a/core/src/test/resources/api/multiple_success/common_ancestor_semi.scala
+++ b/core/src/test/resources/api/multiple_success/common_ancestor_semi.scala
@@ -7,19 +7,19 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val personDecoder: Decoder[Person] =
+  implicit lazy val personDecoder: Decoder[Person] =
     Decoder.forProduct2("name", "age")(Person.apply)
-  implicit val personEncoder: Encoder[Person] =
+  implicit lazy val personEncoder: Encoder[Person] =
     Encoder.forProduct2("name", "age")(p => (p.name, p.age))
-  implicit val organizationDecoder: Decoder[Organization] =
+  implicit lazy val organizationDecoder: Decoder[Organization] =
     Decoder.forProduct1("name")(Organization.apply)
-  implicit val organizationEncoder: Encoder[Organization] =
+  implicit lazy val organizationEncoder: Encoder[Organization] =
     Encoder.forProduct1("name")(p => p.name)
-  implicit val entityDecoder: Decoder[Entity] = List[Decoder[Entity]](
+  implicit lazy val entityDecoder: Decoder[Entity] = List[Decoder[Entity]](
     Decoder[Person].asInstanceOf[Decoder[Entity]],
     Decoder[Organization].asInstanceOf[Decoder[Entity]]
   ).reduceLeft(_ or _)
-  implicit val entityEncoder: Encoder[Entity] = Encoder.instance {
+  implicit lazy val entityEncoder: Encoder[Entity] = Encoder.instance {
     case person: Person =>
       Encoder[Person].apply(person)
     case organization: Organization =>

--- a/core/src/test/resources/api/multiple_success/separate_products.scala
+++ b/core/src/test/resources/api/multiple_success/separate_products.scala
@@ -7,20 +7,20 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val personDecoder: Decoder[Person] =
+  implicit lazy val personDecoder: Decoder[Person] =
     Decoder.forProduct2("name", "age")(Person.apply)
-  implicit val personEncoder: Encoder[Person] =
+  implicit lazy val personEncoder: Encoder[Person] =
     Encoder.forProduct2("name", "age")(p => (p.name, p.age))
-  implicit val organizationDecoder: Decoder[Organization] =
+  implicit lazy val organizationDecoder: Decoder[Organization] =
     Decoder.forProduct1("name")(Organization.apply)
-  implicit val organizationEncoder: Encoder[Organization] =
+  implicit lazy val organizationEncoder: Encoder[Organization] =
     Encoder.forProduct1("name")(p => p.name)
-  implicit val getRootGenericSuccessDecoder: Decoder[GetRootGenericSuccess] =
+  implicit lazy val getRootGenericSuccessDecoder: Decoder[GetRootGenericSuccess] =
     List[Decoder[GetRootGenericSuccess]](
       Decoder[Person].asInstanceOf[Decoder[GetRootGenericSuccess]],
       Decoder[Organization].asInstanceOf[Decoder[GetRootGenericSuccess]]
     ).reduceLeft(_ or _)
-  implicit val getRootGenericSuccessEncoder: Encoder[GetRootGenericSuccess] =
+  implicit lazy val getRootGenericSuccessEncoder: Encoder[GetRootGenericSuccess] =
     Encoder.instance {
       case person: Person =>
         Encoder[Person].apply(person)

--- a/core/src/test/resources/api/open_product/all_of.scala
+++ b/core/src/test/resources/api/open_product/all_of.scala
@@ -10,7 +10,7 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val dogDecoder: Decoder[Dog] = new Decoder[Dog]() {
+  implicit lazy val dogDecoder: Decoder[Dog] = new Decoder[Dog]() {
     override def apply(c: HCursor): Result[Dog] = for (
       className <- c.downField("className").as[String];
       color <- c.downField("color").as[Option[String]];
@@ -27,7 +27,7 @@ trait CirceCodecs extends SttpCirceApi {
           .filterKeys(_ != "breed")
       )
   }
-  implicit val dogEncoder: Encoder[Dog] = new Encoder[Dog]() {
+  implicit lazy val dogEncoder: Encoder[Dog] = new Encoder[Dog]() {
     override def apply(dog: Dog): Json = Encoder
       .forProduct3[Dog, String, Option[String], Option[String]](
         "className",
@@ -37,10 +37,10 @@ trait CirceCodecs extends SttpCirceApi {
       .apply(dog)
       .deepMerge(Encoder[Map[String, Json]].apply(dog._additionalProperties))
   }
-  implicit val animalDecoder: Decoder[Animal] = List[Decoder[Animal]](
+  implicit lazy val animalDecoder: Decoder[Animal] = List[Decoder[Animal]](
     Decoder[Dog].asInstanceOf[Decoder[Animal]]
   ).reduceLeft(_ or _)
-  implicit val animalEncoder: Encoder[Animal] = Encoder.instance {
+  implicit lazy val animalEncoder: Encoder[Animal] = Encoder.instance {
     case dog: Dog =>
       Encoder[Dog].apply(dog)
   }

--- a/core/src/test/resources/api/open_product/free_form.scala
+++ b/core/src/test/resources/api/open_product/free_form.scala
@@ -10,7 +10,7 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val personDecoder: Decoder[Person] = new Decoder[Person]() {
+  implicit lazy val personDecoder: Decoder[Person] = new Decoder[Person]() {
     override def apply(c: HCursor): Result[Person] =
       for {
         name <- c.downField("name").as[String]
@@ -22,7 +22,7 @@ trait CirceCodecs extends SttpCirceApi {
         additionalProperties.filterKeys(_ != "name").filterKeys(_ != "age")
       )
   }
-  implicit val personEncoder: Encoder[Person] = new Encoder[Person]() {
+  implicit lazy val personEncoder: Encoder[Person] = new Encoder[Person]() {
     override def apply(person: Person): Json = Encoder
       .forProduct2[Person, String, Int]("name", "age")(p => (p.name, p.age))
       .apply(person)

--- a/core/src/test/resources/api/open_product/int_values.scala
+++ b/core/src/test/resources/api/open_product/int_values.scala
@@ -10,7 +10,7 @@ import _root_.io.circe.Json
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val personDecoder: Decoder[Person] = new Decoder[Person]() {
+  implicit lazy val personDecoder: Decoder[Person] = new Decoder[Person]() {
     override def apply(c: HCursor): Result[Person] =
       for (
         name <- c.downField("name").as[String];
@@ -25,7 +25,7 @@ trait CirceCodecs extends SttpCirceApi {
             .filterKeys(_ != "age")
         )
   }
-  implicit val personEncoder: Encoder[Person] = new Encoder[Person]() {
+  implicit lazy val personEncoder: Encoder[Person] = new Encoder[Person]() {
     override def apply(person: Person): Json =
       Encoder
         .forProduct2[Person, String, Int]("name", "age")(p => (p.name, p.age))

--- a/core/src/test/resources/api/request_body/array_product.scala
+++ b/core/src/test/resources/api/request_body/array_product.scala
@@ -7,9 +7,9 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val personDecoder: Decoder[Person] =
+  implicit lazy val personDecoder: Decoder[Person] =
     Decoder.forProduct2("name", "age")(Person.apply)
-  implicit val personEncoder: Encoder[Person] =
+  implicit lazy val personEncoder: Encoder[Person] =
     Encoder.forProduct2("name", "age")(p => (p.name, p.age))
 }
 object CirceCodecs extends CirceCodecs

--- a/core/src/test/resources/api/request_body/optional_product.scala
+++ b/core/src/test/resources/api/request_body/optional_product.scala
@@ -7,9 +7,9 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val personDecoder: Decoder[Person] =
+  implicit lazy val personDecoder: Decoder[Person] =
     Decoder.forProduct2("name", "age")(Person.apply)
-  implicit val personEncoder: Encoder[Person] =
+  implicit lazy val personEncoder: Encoder[Person] =
     Encoder.forProduct2("name", "age")(p => (p.name, p.age))
 }
 object CirceCodecs extends CirceCodecs

--- a/core/src/test/resources/api/request_body/product.scala
+++ b/core/src/test/resources/api/request_body/product.scala
@@ -7,9 +7,9 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val personDecoder: Decoder[Person] =
+  implicit lazy val personDecoder: Decoder[Person] =
     Decoder.forProduct2("name", "age")(Person.apply)
-  implicit val personEncoder: Encoder[Person] =
+  implicit lazy val personEncoder: Encoder[Person] =
     Encoder.forProduct2("name", "age")(p => (p.name, p.age))
 }
 object CirceCodecs extends CirceCodecs

--- a/core/src/test/resources/api/request_body/product_form_encoded.scala
+++ b/core/src/test/resources/api/request_body/product_form_encoded.scala
@@ -6,13 +6,13 @@ import _root_.io.circe.Decoder
 import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 trait CirceCodecs extends SttpCirceApi {
-  implicit val personDecoder: Decoder[Person] =
+  implicit lazy val personDecoder: Decoder[Person] =
     Decoder.forProduct2("name", "age")(Person.apply)
-  implicit val personEncoder: Encoder[Person] =
+  implicit lazy val personEncoder: Encoder[Person] =
     Encoder.forProduct2("name", "age")(p => (p.name, p.age))
-  implicit val personBodyDecoder: Decoder[PersonBody] =
+  implicit lazy val personBodyDecoder: Decoder[PersonBody] =
     Decoder.forProduct2("name", "age")(PersonBody.apply)
-  implicit val personBodyEncoder: Encoder[PersonBody] =
+  implicit lazy val personBodyEncoder: Encoder[PersonBody] =
     Encoder.forProduct2("name", "age")(p => (p.name, p.age))
 }
 object CirceCodecs extends CirceCodecs

--- a/core/src/test/resources/api/request_body/request_body_direct.scala
+++ b/core/src/test/resources/api/request_body/request_body_direct.scala
@@ -6,13 +6,13 @@ import _root_.io.circe.Decoder
 import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 trait CirceCodecs extends SttpCirceApi {
-  implicit val petResponseDecoder: Decoder[PetResponse] =
+  implicit lazy val petResponseDecoder: Decoder[PetResponse] =
     Decoder.forProduct1("name")(PetResponse.apply)
-  implicit val petResponseEncoder: Encoder[PetResponse] =
+  implicit lazy val petResponseEncoder: Encoder[PetResponse] =
     Encoder.forProduct1("name")(p => p.name)
-  implicit val petRequestDecoder: Decoder[PetRequest] =
+  implicit lazy val petRequestDecoder: Decoder[PetRequest] =
     Decoder.forProduct1("id")(PetRequest.apply)
-  implicit val petRequestEncoder: Encoder[PetRequest] =
+  implicit lazy val petRequestEncoder: Encoder[PetRequest] =
     Encoder.forProduct1("id")(p => p.id)
 }
 object CirceCodecs extends CirceCodecs

--- a/core/src/test/resources/api/request_body/request_body_indirect.scala
+++ b/core/src/test/resources/api/request_body/request_body_indirect.scala
@@ -6,13 +6,13 @@ import _root_.io.circe.Decoder
 import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 trait CirceCodecs extends SttpCirceApi {
-  implicit val petRequestDecoder: Decoder[PetRequest] =
+  implicit lazy val petRequestDecoder: Decoder[PetRequest] =
     Decoder.forProduct1("id")(PetRequest.apply)
-  implicit val petRequestEncoder: Encoder[PetRequest] =
+  implicit lazy val petRequestEncoder: Encoder[PetRequest] =
     Encoder.forProduct1("id")(p => p.id)
-  implicit val petResponseDecoder: Decoder[PetResponse] =
+  implicit lazy val petResponseDecoder: Decoder[PetResponse] =
     Decoder.forProduct1("name")(PetResponse.apply)
-  implicit val petResponseEncoder: Encoder[PetResponse] =
+  implicit lazy val petResponseEncoder: Encoder[PetResponse] =
     Encoder.forProduct1("name")(p => p.name)
 }
 object CirceCodecs extends CirceCodecs

--- a/core/src/test/resources/api/simple/post.scala
+++ b/core/src/test/resources/api/simple/post.scala
@@ -7,9 +7,9 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val personDecoder: Decoder[Person] =
+  implicit lazy val personDecoder: Decoder[Person] =
     Decoder.forProduct2("name", "age")(Person.apply)
-  implicit val personEncoder: Encoder[Person] =
+  implicit lazy val personEncoder: Encoder[Person] =
     Encoder.forProduct2("name", "age")(p => (p.name, p.age))
 }
 object CirceCodecs extends CirceCodecs

--- a/core/src/test/resources/api/simple/simple_get_nested_products.scala
+++ b/core/src/test/resources/api/simple/simple_get_nested_products.scala
@@ -7,13 +7,13 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val categoryDecoder: Decoder[Category] =
+  implicit lazy val categoryDecoder: Decoder[Category] =
     Decoder.forProduct2("id", "name")(Category.apply)
-  implicit val categoryEncoder: Encoder[Category] =
+  implicit lazy val categoryEncoder: Encoder[Category] =
     Encoder.forProduct2("id", "name")(p => (p.id, p.name))
-  implicit val petDecoder: Decoder[Pet] =
+  implicit lazy val petDecoder: Decoder[Pet] =
     Decoder.forProduct4("id", "name", "category", "status")(Pet.apply)
-  implicit val petEncoder: Encoder[Pet] =
+  implicit lazy val petEncoder: Encoder[Pet] =
     Encoder.forProduct4("id", "name", "category", "status")(p =>
       (p.id, p.name, p.category, p.status)
     )

--- a/core/src/test/resources/api/simple/simple_get_person.scala
+++ b/core/src/test/resources/api/simple/simple_get_person.scala
@@ -7,9 +7,9 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val personDecoder: Decoder[Person] =
+  implicit lazy val personDecoder: Decoder[Person] =
     Decoder.forProduct2("name", "age")(Person.apply)
-  implicit val personEncoder: Encoder[Person] =
+  implicit lazy val personEncoder: Encoder[Person] =
     Encoder.forProduct2("name", "age")(p => (p.name, p.age))
 }
 object CirceCodecs extends CirceCodecs

--- a/core/src/test/resources/api/simple/simple_get_person_optional.scala
+++ b/core/src/test/resources/api/simple/simple_get_person_optional.scala
@@ -7,9 +7,9 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val personDecoder: Decoder[Person] =
+  implicit lazy val personDecoder: Decoder[Person] =
     Decoder.forProduct2("name", "age")(Person.apply)
-  implicit val personEncoder: Encoder[Person] =
+  implicit lazy val personEncoder: Encoder[Person] =
     Encoder.forProduct2("name", "age")(p => (p.name, p.age))
 }
 object CirceCodecs extends CirceCodecs

--- a/core/src/test/resources/api/simple/simple_get_product_array.scala
+++ b/core/src/test/resources/api/simple/simple_get_product_array.scala
@@ -7,13 +7,13 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val categoryDecoder: Decoder[Category] =
+  implicit lazy val categoryDecoder: Decoder[Category] =
     Decoder.forProduct2("id", "name")(Category.apply)
-  implicit val categoryEncoder: Encoder[Category] =
+  implicit lazy val categoryEncoder: Encoder[Category] =
     Encoder.forProduct2("id", "name")(p => (p.id, p.name))
-  implicit val petDecoder: Decoder[Pet] =
+  implicit lazy val petDecoder: Decoder[Pet] =
     Decoder.forProduct4("id", "name", "categories", "status")(Pet.apply)
-  implicit val petEncoder: Encoder[Pet] =
+  implicit lazy val petEncoder: Encoder[Pet] =
     Encoder.forProduct4("id", "name", "categories", "status")(p =>
       (p.id, p.name, p.categories, p.status)
     )

--- a/core/src/test/resources/api/simple/simple_get_reserved.scala
+++ b/core/src/test/resources/api/simple/simple_get_reserved.scala
@@ -7,9 +7,9 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val personDecoder: Decoder[Person] =
+  implicit lazy val personDecoder: Decoder[Person] =
     Decoder.forProduct2("type", "age")(Person.apply)
-  implicit val personEncoder: Encoder[Person] =
+  implicit lazy val personEncoder: Encoder[Person] =
     Encoder.forProduct2("type", "age")(p => (p.`type`, p.age))
 }
 object CirceCodecs extends CirceCodecs

--- a/core/src/test/resources/api/tag/multiple_operations_with_different_tag.scala
+++ b/core/src/test/resources/api/tag/multiple_operations_with_different_tag.scala
@@ -6,9 +6,9 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val personDecoder: Decoder[Person] =
+  implicit lazy val personDecoder: Decoder[Person] =
     Decoder.forProduct2("name", "age")(Person.apply)
-  implicit val personEncoder: Encoder[Person] =
+  implicit lazy val personEncoder: Encoder[Person] =
     Encoder.forProduct2("name", "age")(p => (p.name, p.age))
 }
 object CirceCodecs extends CirceCodecs

--- a/core/src/test/resources/api/tag/multiple_operations_with_same_tag.scala
+++ b/core/src/test/resources/api/tag/multiple_operations_with_same_tag.scala
@@ -7,9 +7,9 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val personDecoder: Decoder[Person] =
+  implicit lazy val personDecoder: Decoder[Person] =
     Decoder.forProduct2("name", "age")(Person.apply)
-  implicit val personEncoder: Encoder[Person] =
+  implicit lazy val personEncoder: Encoder[Person] =
     Encoder.forProduct2("name", "age")(p => (p.name, p.age))
 }
 object CirceCodecs extends CirceCodecs

--- a/core/src/test/resources/api/tag/operation_with_tag.scala
+++ b/core/src/test/resources/api/tag/operation_with_tag.scala
@@ -7,9 +7,9 @@ import _root_.io.circe.Encoder
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val personDecoder: Decoder[Person] =
+  implicit lazy val personDecoder: Decoder[Person] =
     Decoder.forProduct2("name", "age")(Person.apply)
-  implicit val personEncoder: Encoder[Person] =
+  implicit lazy val personEncoder: Encoder[Person] =
     Encoder.forProduct2("name", "age")(p => (p.name, p.age))
 }
 object CirceCodecs extends CirceCodecs

--- a/core/src/test/resources/circe/product.scala
+++ b/core/src/test/resources/circe/product.scala
@@ -1,9 +1,9 @@
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val personDecoder: Decoder[Person] =
+  implicit lazy val personDecoder: Decoder[Person] =
     Decoder.forProduct2("age", "name")(Person.apply)
-  implicit val personEncoder: Encoder[Person] =
+  implicit lazy val personEncoder: Encoder[Person] =
     Encoder.forProduct2("age", "name")(p => (p.age, p.name))
 }
 object CirceCodecs extends CirceCodecs

--- a/core/src/test/resources/circe/string_enum.scala
+++ b/core/src/test/resources/circe/string_enum.scala
@@ -1,7 +1,7 @@
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit val personStatusDecoder: Decoder[PersonStatus] =
+  implicit lazy val personStatusDecoder: Decoder[PersonStatus] =
     Decoder.decodeString.emap {
       case "happy" =>
         Right(PersonStatus.Happy)
@@ -10,7 +10,7 @@ trait CirceCodecs extends SttpCirceApi {
       case other =>
         Left("Unexpected value for enum:" + other)
     }
-  implicit val personStatusEncoder: Encoder[PersonStatus] =
+  implicit lazy val personStatusEncoder: Encoder[PersonStatus] =
     Encoder.encodeString.contramap {
       case PersonStatus.Happy   => "happy"
       case PersonStatus.Neutral => "neutral"

--- a/core/src/test/scala/io/github/ghostbuster91/sttp/client3/openproduct/CirceParsingTest.scala
+++ b/core/src/test/scala/io/github/ghostbuster91/sttp/client3/openproduct/CirceParsingTest.scala
@@ -34,7 +34,7 @@ object CirceParsingTest extends TestSuite {
     }
   }
 
-  implicit val personDecoder: Decoder[Person[Json]] =
+  implicit lazy val personDecoder: Decoder[Person[Json]] =
     new Decoder[Person[Json]] {
       override def apply(c: HCursor): Result[Person[Json]] =
         for {
@@ -48,7 +48,7 @@ object CirceParsingTest extends TestSuite {
         )
     }
 
-  implicit val personEncoder: Encoder[Person[Json]] =
+  implicit lazy val personEncoder: Encoder[Person[Json]] =
     new Encoder[Person[Json]] {
       override def apply(a: Person[Json]): Json =
         Encoder


### PR DESCRIPTION
The `implicit val encoderX ...` need to become lazy, as the hierarchy matters:

```
case class Organization(owner: Person)
case class Person(name: String)

implicit val encoderOrganization: Encoder[Organization] = ...
implicit val encoderPerson: Encoder[Person] = ...
```

The above will throw a `NullPointerException` once you start encoding an `Organization`.