### PR TITLE
Adds support for customizing the date-time type

### DIFF
--- a/core/src/main/scala/io/github/ghostbuster91/sttp/client3/Model.scala
+++ b/core/src/main/scala/io/github/ghostbuster91/sttp/client3/Model.scala
@@ -6,7 +6,6 @@ import io.github.ghostbuster91.sttp.client3.model.{ClassName, ParameterName, Par
 import io.github.ghostbuster91.sttp.client3.openapi._
 import io.github.ghostbuster91.sttp.client3.ImportRegistry._
 
-import java.time.LocalDateTime
 import scala.meta._
 
 case class Model(

--- a/core/src/main/scala/io/github/ghostbuster91/sttp/client3/Model.scala
+++ b/core/src/main/scala/io/github/ghostbuster91/sttp/client3/Model.scala
@@ -2,20 +2,18 @@ package io.github.ghostbuster91.sttp.client3
 
 import cats.data.NonEmptyList
 import cats.syntax.all._
-import io.github.ghostbuster91.sttp.client3.model.{
-  ClassName,
-  ParameterName,
-  ParameterRef
-}
+import io.github.ghostbuster91.sttp.client3.model.{ClassName, ParameterName, ParameterRef}
 import io.github.ghostbuster91.sttp.client3.openapi._
 import io.github.ghostbuster91.sttp.client3.ImportRegistry._
 
+import java.time.LocalDateTime
 import scala.meta._
 
 case class Model(
     schemas: Map[SchemaRef, SafeSchema],
     classNames: Map[SchemaRef, ClassName],
-    childToParentRef: Map[SchemaRef, List[SchemaRef]]
+    childToParentRef: Map[SchemaRef, List[SchemaRef]],
+    typeMappings: TypesMapping
 ) {
 
   def classNameFor(schemaRef: SchemaRef): ClassName = classNames(schemaRef)
@@ -65,9 +63,12 @@ case class Model(
         registerExternalTpe(q"import _root_.java.time.LocalDate").map(tpe =>
           ParameterRef(tpe, ParameterName("localDate"), None)
         )
-      case _: SafeDateTimeSchema =>
-        registerExternalTpe(q"import _root_.java.time.LocalDateTime").map(tpe =>
-          ParameterRef(tpe, ParameterName("localDateTime"), None)
+      case sdt: SafeDateTimeSchema =>
+        val dateTimeType = s"_root_.${typeMappings.dateTime.getName}"
+        val importer = Import(List(dateTimeType.parse[Importer].get))
+
+        registerExternalTpe(importer).map(tpe =>
+          ParameterRef(tpe, ParameterName("dateTime"), None)
         )
       case s: SafeArraySchema =>
         schemaToParameter(s.items).map { itemTypeRef =>
@@ -118,7 +119,8 @@ case class Model(
 object Model {
   def apply(
       schemas: Map[String, SafeSchema],
-      requestBodies: Map[String, SafeSchema]
+      requestBodies: Map[String, SafeSchema],
+      typeMappings: TypesMapping
   ): Model = {
     val adjSchemas = schemas.map { case (k, v) => SchemaRef.schema(k) -> v }
     val adjReqBodies = requestBodies.map { case (k, v) =>
@@ -134,7 +136,8 @@ object Model {
     new Model(
       refToSchema,
       modelClassNames,
-      childToParentRef
+      childToParentRef,
+      typeMappings
     )
   }
 

--- a/core/src/test/resources/api/format/date-time-as-instant.scala
+++ b/core/src/test/resources/api/format/date-time-as-instant.scala
@@ -1,0 +1,26 @@
+package io.github.ghostbuster91.sttp.client3.example
+
+import _root_.sttp.client3._
+import _root_.sttp.model._
+
+import _root_.java.time.Instant
+import _root_.sttp.client3.circe.SttpCirceApi
+
+trait CirceCodecs extends SttpCirceApi
+object CirceCodecs extends CirceCodecs
+
+class DefaultApi(baseUrl: String, circeCodecs: CirceCodecs = CirceCodecs) {
+  import circeCodecs._
+
+  def getRoot(): Request[Instant, Any] = basicRequest
+    .get(uri"$baseUrl")
+    .response(
+      fromMetadata(
+        asJson[Instant].getRight,
+        ConditionalResponseAs(
+          _.code == StatusCode.unsafeApply(200),
+          asJson[Instant].getRight
+        )
+      )
+    )
+}

--- a/core/src/test/resources/api/format/date-time-as-instant.yaml
+++ b/core/src/test/resources/api/format/date-time-as-instant.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.3
+info:
+  title: Entities
+  version: "1.0"
+paths:
+  /:
+    get:
+      operationId: getRoot
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                type: string
+                format: date-time

--- a/core/src/test/resources/api/format/date-time.scala
+++ b/core/src/test/resources/api/format/date-time.scala
@@ -1,0 +1,26 @@
+package io.github.ghostbuster91.sttp.client3.example
+
+import _root_.sttp.client3._
+import _root_.sttp.model._
+
+import _root_.java.time.LocalDateTime
+import _root_.sttp.client3.circe.SttpCirceApi
+
+trait CirceCodecs extends SttpCirceApi
+object CirceCodecs extends CirceCodecs
+
+class DefaultApi(baseUrl: String, circeCodecs: CirceCodecs = CirceCodecs) {
+  import circeCodecs._
+
+  def getRoot(): Request[LocalDateTime, Any] = basicRequest
+    .get(uri"$baseUrl")
+    .response(
+      fromMetadata(
+        asJson[LocalDateTime].getRight,
+        ConditionalResponseAs(
+          _.code == StatusCode.unsafeApply(200),
+          asJson[LocalDateTime].getRight
+        )
+      )
+    )
+}

--- a/core/src/test/resources/api/format/date-time.yaml
+++ b/core/src/test/resources/api/format/date-time.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.3
+info:
+  title: Entities
+  version: "1.0"
+paths:
+  /:
+    get:
+      operationId: getRoot
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                type: string
+                format: date-time

--- a/core/src/test/scala/io/github/ghostbuster91/sttp/client3/PetStoreTest.scala
+++ b/core/src/test/scala/io/github/ghostbuster91/sttp/client3/PetStoreTest.scala
@@ -17,7 +17,8 @@ object PetStoreTest extends TestSuite {
       CodegenConfig(
         handleErrors = true,
         JsonLibrary.Circe,
-        minimize = true
+        minimize = true,
+        TypesMapping()
       )
     )
     val result = codegen

--- a/parser/src/main/scala/io/github.ghostbuster91/sttp/client3/openapi/SafeOpenApi.scala
+++ b/parser/src/main/scala/io/github.ghostbuster91/sttp/client3/openapi/SafeOpenApi.scala
@@ -159,9 +159,6 @@ sealed trait SafeSchema {
   def isEnum: Boolean = enum.nonEmpty
   def isArray = false
   override def toString: String = unsafe.toString
-
-  def getTypeFormat: (String, String) =
-    unsafe.getType -> unsafe.getFormat
 }
 sealed trait SchemaWithProperties extends SafeSchema {
   def properties: Map[String, SafeSchema] = Option(unsafe.getProperties)

--- a/parser/src/main/scala/io/github.ghostbuster91/sttp/client3/openapi/SafeOpenApi.scala
+++ b/parser/src/main/scala/io/github.ghostbuster91/sttp/client3/openapi/SafeOpenApi.scala
@@ -159,6 +159,9 @@ sealed trait SafeSchema {
   def isEnum: Boolean = enum.nonEmpty
   def isArray = false
   override def toString: String = unsafe.toString
+
+  def getTypeFormat: (String, String) =
+    unsafe.getType -> unsafe.getFormat
 }
 sealed trait SchemaWithProperties extends SafeSchema {
   def properties: Map[String, SafeSchema] = Option(unsafe.getProperties)

--- a/sbt-codegen-plugin/src/main/scala/io/github/ghostbuster91/sttp/client3/SttpOpenApiCodegenPlugin.scala
+++ b/sbt-codegen-plugin/src/main/scala/io/github/ghostbuster91/sttp/client3/SttpOpenApiCodegenPlugin.scala
@@ -4,8 +4,8 @@ import io.github.ghostbuster91.sttp.client3.SbtCodegenAdapter.FileOpts
 import sbt.{AutoPlugin, Def, File}
 import org.scalafmt.interfaces.Scalafmt
 import sbt.internal.util.ManagedLogger
-import sbt.Keys.*
-import sbt.*
+import sbt.Keys._
+import sbt._
 
 object SttpOpenApiCodegenPlugin extends AutoPlugin {
 

--- a/sbt-codegen-plugin/src/main/scala/io/github/ghostbuster91/sttp/client3/SttpOpenApiCodegenPlugin.scala
+++ b/sbt-codegen-plugin/src/main/scala/io/github/ghostbuster91/sttp/client3/SttpOpenApiCodegenPlugin.scala
@@ -4,8 +4,8 @@ import io.github.ghostbuster91.sttp.client3.SbtCodegenAdapter.FileOpts
 import sbt.{AutoPlugin, Def, File}
 import org.scalafmt.interfaces.Scalafmt
 import sbt.internal.util.ManagedLogger
-import sbt.Keys._
-import sbt._
+import sbt.Keys.*
+import sbt.*
 
 object SttpOpenApiCodegenPlugin extends AutoPlugin {
 
@@ -26,6 +26,11 @@ object SttpOpenApiCodegenPlugin extends AutoPlugin {
     "If true the generator will render model classes only if they are referenced by any of the exiting operations"
   )
 
+  val sttpOpenApiTypesMapping =
+    settingKey[TypesMapping](
+      "Configuration settings for sttp-openapi generator to use"
+    )
+
   object autoImport {
 
     lazy val generateSources =
@@ -37,7 +42,8 @@ object SttpOpenApiCodegenPlugin extends AutoPlugin {
         val config = CodegenConfig(
           handleErrors = sttpOpenApiHandleErrors.value,
           sttpOpenApiJsonLibrary.value,
-          sttpOpenApiMinimizeOutput.value
+          sttpOpenApiMinimizeOutput.value,
+          sttpOpenApiTypesMapping.value
         )
         val codegen = new SbtCodegenAdapter(
           config,
@@ -152,7 +158,8 @@ object SttpOpenApiCodegenPlugin extends AutoPlugin {
       Compile / sourceGenerators += generateSources.taskValue,
       libraryDependencies ++= coreDeps ++ (sttpOpenApiJsonLibrary.value match {
         case JsonLibrary.Circe => circeDeps
-      })
+      }),
+      sttpOpenApiTypesMapping := TypesMapping()
     )
 
   sealed trait Input


### PR DESCRIPTION
This PR adds support for customizing the `date-time` representation. The default is currently set to `LocalDateTime`, which is not an ideal type if you need zone information. To not break any existing consumers, we decided to use `LocalDateTime` as the default representation.

P.S. If you like the approach, my colleague and I can refactor `LocalDate` as well in the same style within this PR. In the future you can even use the same setup for things like e-mail formatting, which is currently not supported in this generator.