### PR TITLE
Moves the configuration classes to the sbt-codegen-plugin

### DIFF
--- a/mill-codegen-plugin/src/io/github/ghostbuster91/sttp/client3/OpenApiCodegenScalaModule.scala
+++ b/mill-codegen-plugin/src/io/github/ghostbuster91/sttp/client3/OpenApiCodegenScalaModule.scala
@@ -9,7 +9,7 @@ import upickle.default.*
 
 import java.time.LocalDateTime
 
-import implicits._
+import Implicits._
 
 trait OpenApiCodegenScalaModule extends ScalaModule {
 
@@ -167,19 +167,11 @@ object OpenApiCodegenScalaModule {
   sealed trait Input
   object Input {
     case class SingleFile(file: Path, pkg: String) extends Input
-    object SingleFile {
-      implicit val rw: ReadWriter[SingleFile] = macroRW
-    }
+
     case class Directory(directory: Path, basePkg: Option[String]) extends Input
-    object Directory {
-      implicit val rw: ReadWriter[Directory] = macroRW
-    }
 
     def dir(path: Path, basePkg: Option[String] = None): Input =
       Input.Directory(path, basePkg)
-
-    implicit val rw: ReadWriter[Input] =
-      ReadWriter.merge(SingleFile.rw, Directory.rw)
   }
 
   case class TypesMapping(dateTime: Class[_] = classOf[LocalDateTime])
@@ -190,7 +182,4 @@ object OpenApiCodegenScalaModule {
   }
 
   case class FileOpts(pkg: String, relPath: RelPath)
-  object FileOpts {
-    implicit val rw: ReadWriter[FileOpts] = macroRW
-  }
 }

--- a/mill-codegen-plugin/src/io/github/ghostbuster91/sttp/client3/OpenApiCodegenScalaModule.scala
+++ b/mill-codegen-plugin/src/io/github/ghostbuster91/sttp/client3/OpenApiCodegenScalaModule.scala
@@ -7,6 +7,10 @@ import mill.scalalib.*
 import os.{Path, RelPath}
 import upickle.default.*
 
+import java.time.LocalDateTime
+
+import implicits._
+
 trait OpenApiCodegenScalaModule extends ScalaModule {
 
   /** Input resources for sttp-openapi generator
@@ -61,9 +65,9 @@ trait OpenApiCodegenScalaModule extends ScalaModule {
         )
         val config = CodegenConfig(
           handleErrors = sttpOpenApiHandleErrors(),
-          sttpOpenApiJsonLibrary(),
+          sttpOpenApiJsonLibrary().convert,
           sttpOpenApiMinimizeOutput(),
-          sttpOpenApiTypesMapping()
+          sttpOpenApiTypesMapping().convert
         )
         val input = os.read.lines(path).mkString("\n")
         val result =
@@ -178,31 +182,15 @@ object OpenApiCodegenScalaModule {
       ReadWriter.merge(SingleFile.rw, Directory.rw)
   }
 
-  implicit def relPathRw: ReadWriter[RelPath] =
-    implicitly[ReadWriter[IndexedSeq[String]]]
-      .bimap[RelPath](
-        v => v.segments,
-        g => RelPath(g, 0)
-      )
+  case class TypesMapping(dateTime: Class[_] = classOf[LocalDateTime])
+
+  sealed trait JsonLibrary
+  object JsonLibrary {
+    object Circe extends JsonLibrary
+  }
 
   case class FileOpts(pkg: String, relPath: RelPath)
   object FileOpts {
     implicit val rw: ReadWriter[FileOpts] = macroRW
   }
-
-//  implicit def classRw: ReadWriter[Class[Any]] = implicitly[ReadWriter[String]]
-//    .bimap[Class[Any]](
-//      v => v.getName,
-//      g => Class.forName(g).asInstanceOf[Class[Any]]
-//    )
-
-  implicit val typesMappingRw: ReadWriter[TypesMapping] =
-    implicitly[ReadWriter[Map[String, String]]].bimap[TypesMapping](
-      v => Map("dateTime" -> v.dateTime.getName),
-      g => TypesMapping(dateTime = Class.forName(g("dateTime")))
-    )
-
-  implicit val jsonLibraryCirceRw: ReadWriter[JsonLibrary.Circe.type] = macroRW
-  implicit val jsonLibraryRw: ReadWriter[JsonLibrary] =
-    ReadWriter.merge(jsonLibraryCirceRw)
 }

--- a/mill-codegen-plugin/src/io/github/ghostbuster91/sttp/client3/implicits/implicits.scala
+++ b/mill-codegen-plugin/src/io/github/ghostbuster91/sttp/client3/implicits/implicits.scala
@@ -1,0 +1,43 @@
+package io.github.ghostbuster91.sttp.client3
+
+import io.github.ghostbuster91.sttp.client3.OpenApiCodegenScalaModule.{JsonLibrary as PluginJsonLibrary, TypesMapping as PluginTypesMapping}
+import io.github.ghostbuster91.sttp.client3.{JsonLibrary as CoreJsonLibrary, TypesMapping as CoreTypesMapping}
+
+import os.RelPath
+import upickle.default.*
+
+package object implicits {
+  implicit class JsonLibraryHelper(value: PluginJsonLibrary) {
+    def convert: CoreJsonLibrary = value match {
+      case PluginJsonLibrary.Circe => CoreJsonLibrary.Circe
+    }
+  }
+
+  implicit class TypesMappingHelper(value: PluginTypesMapping) {
+    def convert: CoreTypesMapping =
+      CoreTypesMapping(dateTime = value.dateTime)
+  }
+
+  implicit def relPathRw: ReadWriter[RelPath] =
+    implicitly[ReadWriter[IndexedSeq[String]]]
+      .bimap[RelPath](
+        v => v.segments,
+        g => RelPath(g, 0)
+      )
+
+  //  implicit def classRw: ReadWriter[Class[Any]] = implicitly[ReadWriter[String]]
+  //    .bimap[Class[Any]](
+  //      v => v.getName,
+  //      g => Class.forName(g).asInstanceOf[Class[Any]]
+  //    )
+
+  implicit val typesMappingRw: ReadWriter[PluginTypesMapping] =
+    implicitly[ReadWriter[Map[String, String]]].bimap[PluginTypesMapping](
+      v => Map("dateTime" -> v.dateTime.getName),
+      g => PluginTypesMapping(dateTime = Class.forName(g("dateTime")))
+    )
+
+  implicit val jsonLibraryCirceRw: ReadWriter[PluginJsonLibrary.Circe.type] = macroRW
+  implicit val jsonLibraryRw: ReadWriter[PluginJsonLibrary] =
+    ReadWriter.merge(jsonLibraryCirceRw)
+}

--- a/sbt-codegen-plugin/src/main/scala/io/github/ghostbuster91/sttp/client3/SttpOpenApiCodegenPlugin.scala
+++ b/sbt-codegen-plugin/src/main/scala/io/github/ghostbuster91/sttp/client3/SttpOpenApiCodegenPlugin.scala
@@ -4,8 +4,12 @@ import io.github.ghostbuster91.sttp.client3.SbtCodegenAdapter.FileOpts
 import sbt.{AutoPlugin, Def, File}
 import org.scalafmt.interfaces.Scalafmt
 import sbt.internal.util.ManagedLogger
-import sbt.Keys._
-import sbt._
+import sbt.Keys.*
+import sbt.*
+
+import java.time.LocalDateTime
+
+import implicits._
 
 object SttpOpenApiCodegenPlugin extends AutoPlugin {
 
@@ -41,9 +45,9 @@ object SttpOpenApiCodegenPlugin extends AutoPlugin {
         val scalafmt = Scalafmt.create(this.getClass.getClassLoader)
         val config = CodegenConfig(
           handleErrors = sttpOpenApiHandleErrors.value,
-          sttpOpenApiJsonLibrary.value,
+          sttpOpenApiJsonLibrary.value.convert,
           sttpOpenApiMinimizeOutput.value,
-          sttpOpenApiTypesMapping.value
+          sttpOpenApiTypesMapping.value.convert
         )
         val codegen = new SbtCodegenAdapter(
           config,
@@ -166,5 +170,12 @@ object SttpOpenApiCodegenPlugin extends AutoPlugin {
   object Input {
     case class SingleFile(file: File, pkg: String) extends Input
     case class Directory(directory: File, basePkg: Option[String]) extends Input
+  }
+
+  case class TypesMapping(dateTime: Class[_] = classOf[LocalDateTime])
+
+  sealed trait JsonLibrary
+  object JsonLibrary {
+    object Circe extends JsonLibrary
   }
 }

--- a/sbt-codegen-plugin/src/main/scala/io/github/ghostbuster91/sttp/client3/implicits/implicits.scala
+++ b/sbt-codegen-plugin/src/main/scala/io/github/ghostbuster91/sttp/client3/implicits/implicits.scala
@@ -1,0 +1,17 @@
+package io.github.ghostbuster91.sttp.client3
+
+import io.github.ghostbuster91.sttp.client3.SttpOpenApiCodegenPlugin.{JsonLibrary as PluginJsonLibrary, TypesMapping as PluginTypesMapping}
+import io.github.ghostbuster91.sttp.client3.{JsonLibrary as CoreJsonLibrary, TypesMapping as CoreTypesMapping}
+
+package object implicits {
+  implicit class JsonLibraryHelper(value: PluginJsonLibrary) {
+    def convert: CoreJsonLibrary = value match {
+      case PluginJsonLibrary.Circe => CoreJsonLibrary.Circe
+    }
+  }
+
+  implicit class TypesMappingHelper(value: PluginTypesMapping) {
+    def convert: CoreTypesMapping =
+      CoreTypesMapping(dateTime = value.dateTime)
+  }
+}


### PR DESCRIPTION
The configuration classes have been moved to the sbt-codegen-plugin, so that they become accessible from the sbt settings. We've created a mapping from the sbt-codegen-plugin domain to the codegen-core, so that the codegen-core dependencies don't leak to the outside world.