### PR TITLE
Adds support for custom date type

### DIFF
--- a/core/src/main/scala/io/github/ghostbuster91/sttp/client3/Codegen.scala
+++ b/core/src/main/scala/io/github/ghostbuster91/sttp/client3/Codegen.scala
@@ -9,7 +9,7 @@ import scala.meta._
 import sttp.model.MediaType
 import sttp.model.Method
 
-import java.time.LocalDateTime
+import java.time.{LocalDate, LocalDateTime}
 
 class Codegen(logger: LogAdapter, config: CodegenConfig) {
   def generateUnsafe(openApiYaml: String, packageName: Option[String]): Source =
@@ -168,7 +168,8 @@ case class CodegenConfig(
     typesMapping: TypesMapping = TypesMapping()
 )
 
-case class TypesMapping(dateTime: Class[_] = classOf[LocalDateTime])
+case class TypesMapping(dateTime: Class[_] = classOf[LocalDateTime],
+                        date: Class[_] = classOf[LocalDate])
 
 case class CodegenOutput(
     processedOps: Map[Option[String], List[Defn.Def]],

--- a/core/src/main/scala/io/github/ghostbuster91/sttp/client3/LogAdapter.scala
+++ b/core/src/main/scala/io/github/ghostbuster91/sttp/client3/LogAdapter.scala
@@ -5,8 +5,5 @@ trait LogAdapter {
 }
 
 object LogAdapter {
-  val StdOut: LogAdapter = new LogAdapter {
-    override def warn(msg: String): Unit =
-      println(s"Warning: $msg")
-  }
+  val StdOut: LogAdapter = (msg: String) => println(s"Warning: $msg")
 }

--- a/core/src/main/scala/io/github/ghostbuster91/sttp/client3/Model.scala
+++ b/core/src/main/scala/io/github/ghostbuster91/sttp/client3/Model.scala
@@ -63,12 +63,15 @@ case class Model(
       case sb: SafeBooleanSchema =>
         ParameterRef("Boolean", sb.default.map(Lit.Boolean(_))).pure[IM]
       case _: SafeDateSchema =>
-        registerExternalTpe(q"import _root_.java.time.LocalDate").map(tpe =>
-          ParameterRef(tpe, ParameterName("localDate"), None)
+        val mappingType = s"_root_.${typeMappings.date.getName}"
+        val importer = Import(List(mappingType.parse[Importer].get))
+
+        registerExternalTpe(importer).map(tpe =>
+          ParameterRef(tpe, ParameterName("date"), None)
         )
-      case sdt: SafeDateTimeSchema =>
-        val dateTimeType = s"_root_.${typeMappings.dateTime.getName}"
-        val importer = Import(List(dateTimeType.parse[Importer].get))
+      case _: SafeDateTimeSchema =>
+        val mappingType = s"_root_.${typeMappings.dateTime.getName}"
+        val importer = Import(List(mappingType.parse[Importer].get))
 
         registerExternalTpe(importer).map(tpe =>
           ParameterRef(tpe, ParameterName("dateTime"), None)

--- a/core/src/test/resources/api/format/date-as-instant.scala
+++ b/core/src/test/resources/api/format/date-as-instant.scala
@@ -1,0 +1,26 @@
+package io.github.ghostbuster91.sttp.client3.example
+
+import _root_.sttp.client3._
+import _root_.sttp.model._
+
+import _root_.java.time.Instant
+import _root_.sttp.client3.circe.SttpCirceApi
+
+trait CirceCodecs extends SttpCirceApi
+object CirceCodecs extends CirceCodecs
+
+class DefaultApi(baseUrl: String, circeCodecs: CirceCodecs = CirceCodecs) {
+  import circeCodecs._
+
+  def getRoot(): Request[Instant, Any] = basicRequest
+    .get(uri"$baseUrl")
+    .response(
+      fromMetadata(
+        asJson[Instant].getRight,
+        ConditionalResponseAs(
+          _.code == StatusCode.unsafeApply(200),
+          asJson[Instant].getRight
+        )
+      )
+    )
+}

--- a/core/src/test/resources/api/format/date-as-instant.yaml
+++ b/core/src/test/resources/api/format/date-as-instant.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.3
+info:
+  title: Entities
+  version: "1.0"
+paths:
+  /:
+    get:
+      operationId: getRoot
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                type: string
+                format: date

--- a/core/src/test/resources/api/format/date.scala
+++ b/core/src/test/resources/api/format/date.scala
@@ -1,0 +1,26 @@
+package io.github.ghostbuster91.sttp.client3.example
+
+import _root_.sttp.client3._
+import _root_.sttp.model._
+
+import _root_.java.time.LocalDate
+import _root_.sttp.client3.circe.SttpCirceApi
+
+trait CirceCodecs extends SttpCirceApi
+object CirceCodecs extends CirceCodecs
+
+class DefaultApi(baseUrl: String, circeCodecs: CirceCodecs = CirceCodecs) {
+  import circeCodecs._
+
+  def getRoot(): Request[LocalDate, Any] = basicRequest
+    .get(uri"$baseUrl")
+    .response(
+      fromMetadata(
+        asJson[LocalDate].getRight,
+        ConditionalResponseAs(
+          _.code == StatusCode.unsafeApply(200),
+          asJson[LocalDate].getRight
+        )
+      )
+    )
+}

--- a/core/src/test/resources/api/format/date.yaml
+++ b/core/src/test/resources/api/format/date.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.3
+info:
+  title: Entities
+  version: "1.0"
+paths:
+  /:
+    get:
+      operationId: getRoot
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                type: string
+                format: date

--- a/core/src/test/scala/io/github/ghostbuster91/sttp/client3/GeneratorTest.scala
+++ b/core/src/test/scala/io/github/ghostbuster91/sttp/client3/GeneratorTest.scala
@@ -1,5 +1,6 @@
 package io.github.ghostbuster91.sttp.client3
 
+import org.joda.time.DateTime
 import utest._
 
 import java.time.Instant
@@ -102,6 +103,7 @@ object GeneratorTest extends TestSuite {
       "date-time-as-instant" - test(
         CodegenConfig(typesMapping = TypesMapping(dateTime = classOf[Instant]))
       )
+      "date" - test()
     }
 
     "header" - {
@@ -124,7 +126,7 @@ object GeneratorTest extends TestSuite {
 
   def testNoCompile(
       codeGenConfig: CodegenConfig = CodegenConfig()
-  )(implicit testPath: utest.framework.TestPath) = {
+  )(implicit testPath: utest.framework.TestPath): Unit = {
     val testName = testPath.value.mkString("/")
     val yaml = load(s"$testName.yaml")
     val result = new Codegen(
@@ -141,7 +143,7 @@ object GeneratorTest extends TestSuite {
 
   def test(
       codeGenConfig: CodegenConfig = CodegenConfig()
-  )(implicit testPath: utest.framework.TestPath) = {
+  )(implicit testPath: utest.framework.TestPath): Unit = {
     testNoCompile(codeGenConfig)
     val testName = testPath.value.mkString("/")
     val expected = load(s"$testName.scala")

--- a/core/src/test/scala/io/github/ghostbuster91/sttp/client3/GeneratorTest.scala
+++ b/core/src/test/scala/io/github/ghostbuster91/sttp/client3/GeneratorTest.scala
@@ -104,6 +104,9 @@ object GeneratorTest extends TestSuite {
         CodegenConfig(typesMapping = TypesMapping(dateTime = classOf[Instant]))
       )
       "date" - test()
+      "date-as-instant" - test(
+        CodegenConfig(typesMapping = TypesMapping(date = classOf[Instant]))
+      )
     }
 
     "header" - {

--- a/mill-codegen-plugin/src/io/github/ghostbuster91/sttp/client3/Implicits.scala
+++ b/mill-codegen-plugin/src/io/github/ghostbuster91/sttp/client3/Implicits.scala
@@ -23,7 +23,7 @@ object Implicits extends JsonFormatters {
 
   implicit class TypesMappingHelper(value: PluginTypesMapping) {
     def convert: CoreTypesMapping =
-      CoreTypesMapping(dateTime = value.dateTime)
+      CoreTypesMapping(dateTime = value.dateTime, date = value.date)
   }
 
   implicit val relPathRw: ReadWriter[RelPath] =
@@ -35,8 +35,16 @@ object Implicits extends JsonFormatters {
 
   implicit val typesMappingRw: ReadWriter[PluginTypesMapping] =
     implicitly[ReadWriter[Map[String, String]]].bimap[PluginTypesMapping](
-      v => Map("dateTime" -> v.dateTime.getName),
-      g => PluginTypesMapping(dateTime = Class.forName(g("dateTime")))
+      v =>
+        Map(
+          "dateTime" -> v.dateTime.getName,
+          "date" -> v.date.getName
+        ),
+      g =>
+        PluginTypesMapping(
+          dateTime = Class.forName(g("dateTime")),
+          date = Class.forName(g("date"))
+        )
     )
 
   implicit val jsonLibraryCirceRw: ReadWriter[PluginJsonLibrary.Circe.type] =
@@ -47,9 +55,9 @@ object Implicits extends JsonFormatters {
   implicit val fileOpts: ReadWriter[FileOpts] = macroRW
 
   implicit val singleFileRw
-  : ReadWriter[OpenApiCodegenScalaModule.Input.SingleFile] = macroRW
+      : ReadWriter[OpenApiCodegenScalaModule.Input.SingleFile] = macroRW
   implicit val directoryRw
-  : ReadWriter[OpenApiCodegenScalaModule.Input.Directory] = macroRW
+      : ReadWriter[OpenApiCodegenScalaModule.Input.Directory] = macroRW
 
   implicit val inputRw: ReadWriter[OpenApiCodegenScalaModule.Input] =
     ReadWriter.merge(
@@ -57,4 +65,3 @@ object Implicits extends JsonFormatters {
       directoryRw
     )
 }
-

--- a/mill-codegen-plugin/src/io/github/ghostbuster91/sttp/client3/OpenApiCodegenScalaModule.scala
+++ b/mill-codegen-plugin/src/io/github/ghostbuster91/sttp/client3/OpenApiCodegenScalaModule.scala
@@ -7,9 +7,8 @@ import mill.scalalib.*
 import os.{Path, RelPath}
 import upickle.default.*
 
-import java.time.LocalDateTime
-
-import Implicits._
+import java.time.{LocalDate, LocalDateTime}
+import Implicits.*
 
 trait OpenApiCodegenScalaModule extends ScalaModule {
 
@@ -174,7 +173,10 @@ object OpenApiCodegenScalaModule {
       Input.Directory(path, basePkg)
   }
 
-  case class TypesMapping(dateTime: Class[_] = classOf[LocalDateTime])
+  case class TypesMapping(
+      dateTime: Class[_] = classOf[LocalDateTime],
+      date: Class[_] = classOf[LocalDate]
+  )
 
   sealed trait JsonLibrary
   object JsonLibrary {

--- a/sbt-codegen-plugin/src/main/scala/io/github/ghostbuster91/sttp/client3/SttpOpenApiCodegenPlugin.scala
+++ b/sbt-codegen-plugin/src/main/scala/io/github/ghostbuster91/sttp/client3/SttpOpenApiCodegenPlugin.scala
@@ -7,9 +7,8 @@ import sbt.internal.util.ManagedLogger
 import sbt.Keys.*
 import sbt.*
 
-import java.time.LocalDateTime
-
-import implicits._
+import java.time.{LocalDate, LocalDateTime}
+import implicits.*
 
 object SttpOpenApiCodegenPlugin extends AutoPlugin {
 
@@ -172,7 +171,10 @@ object SttpOpenApiCodegenPlugin extends AutoPlugin {
     case class Directory(directory: File, basePkg: Option[String]) extends Input
   }
 
-  case class TypesMapping(dateTime: Class[_] = classOf[LocalDateTime])
+  case class TypesMapping(
+      dateTime: Class[_] = classOf[LocalDateTime],
+      date: Class[_] = classOf[LocalDate]
+  )
 
   sealed trait JsonLibrary
   object JsonLibrary {

--- a/sbt-codegen-plugin/src/main/scala/io/github/ghostbuster91/sttp/client3/implicits/implicits.scala
+++ b/sbt-codegen-plugin/src/main/scala/io/github/ghostbuster91/sttp/client3/implicits/implicits.scala
@@ -12,6 +12,6 @@ package object implicits {
 
   implicit class TypesMappingHelper(value: PluginTypesMapping) {
     def convert: CoreTypesMapping =
-      CoreTypesMapping(dateTime = value.dateTime)
+      CoreTypesMapping(dateTime = value.dateTime, date = value.date)
   }
 }


### PR DESCRIPTION
I would love to add a test for the custom data type, but it fails to find the specific implicit of `Encoder[org.joda.time.DateTime]`. Which makes sense, I'm just wondering how I can bring it on scope in the test. Do you have any idea perhaps?