### PR TITLE
Support implicit discriminator mapping in Encoder/Decoder generation

### DIFF
--- a/core/src/main/scala/io/github/ghostbuster91/sttp/client3/json/circe/CirceCoproductCodecGenerator.scala
+++ b/core/src/main/scala/io/github/ghostbuster91/sttp/client3/json/circe/CirceCoproductCodecGenerator.scala
@@ -143,12 +143,11 @@ private[circe] class CirceCoproductCodecGenerator() {
   private def mergeMappings(
       explicitMapping: Map[String, ClassName],
       implicitMapping: Map[String, ClassName]
-  ): Map[String, ClassName] =
-    (explicitMapping.toSeq ++ implicitMapping.toSeq)
-      .groupBy(_._2)
-      .values
-      .map(_.head)
-      .toMap
+  ): Map[String, ClassName] = {
+    val explicitMappingByClassName = explicitMapping.map(_.swap)
+    val implicitMappingByClassName = implicitMapping.map(_.swap)
+    (implicitMappingByClassName ++ explicitMappingByClassName).map(_.swap)
+  }
 
   private def decoderCaseForString(discValue: String, child: ClassName) =
     p"case $discValue => Decoder[${child.typeName}].apply(c)"

--- a/core/src/main/scala/io/github/ghostbuster91/sttp/client3/json/circe/CirceCoproductCodecGenerator.scala
+++ b/core/src/main/scala/io/github/ghostbuster91/sttp/client3/json/circe/CirceCoproductCodecGenerator.scala
@@ -2,6 +2,7 @@ package io.github.ghostbuster91.sttp.client3.json.circe
 
 import io.github.ghostbuster91.sttp.client3.ImportRegistry._
 import io.github.ghostbuster91.sttp.client3.model._
+
 import scala.meta._
 
 private[circe] class CirceCoproductCodecGenerator() {
@@ -17,69 +18,71 @@ private[circe] class CirceCoproductCodecGenerator() {
   private def encoder(coproduct: Coproduct): IM[Defn.Val] = {
     val coproductType = coproduct.typeName
     val encoderName = coproduct.asPrefix("Encoder")
-    coproduct.discriminator match {
-      case Some(discriminator) if discriminator.mapping.nonEmpty =>
-        for {
-          jsonTpe <- CirceTypeProvider.AnyType
-          encoderTpe <- CirceTypeProvider.EncoderTpe
-        } yield {
-          val cases = encoderCasesWithMapping(discriminator)
-          val encoderInit = init"${t"$encoderTpe[$coproductType]"}()"
-          q"""implicit lazy val $encoderName: $encoderTpe[$coproductType] = new $encoderInit {
-            override def apply(${coproduct.toVar}: $coproductType): $jsonTpe = 
-              ${coproduct.toVar} match {
-                ..case $cases
-                }
-            }
-            """
+    for {
+      encoderTpe <- CirceTypeProvider.EncoderTpe
+    } yield {
+      val cases = encoderCases(coproduct)
+      val encoderInit = init"${t"$encoderTpe[$coproductType]"}()"
+      q"""implicit lazy val $encoderName: $encoderTpe[$coproductType] = Encoder.instance {
+            ..case $cases
         }
-      case _ =>
-        for {
-          encoderTpe <- CirceTypeProvider.EncoderTpe
-        } yield {
-          val cases = encoderCases(coproduct)
-          val encoderInit = init"${t"$encoderTpe[$coproductType]"}()"
-          q"""implicit lazy val $encoderName: $encoderTpe[$coproductType] = Encoder.instance {
-                ..case $cases
-            }
-            """
-        }
+        """
     }
   }
 
-  private def decoder(coproduct: Coproduct): IM[Defn.Val] = {
-    val coproductType = coproduct.typeName
-    val decoderName = coproduct.asPrefix("Decoder")
+  private def decoder(coproduct: Coproduct): IM[Defn.Val] =
     coproduct.discriminator match {
       case Some(discriminator) if discriminator.mapping.nonEmpty =>
-        for {
-          hCursorTpe <- CirceTypeProvider.HCursorTpe
-          decoderTpe <- CirceTypeProvider.DecoderTpe
-          failureTpe <- CirceTypeProvider.DecodingFailureTpe
-          resultTpe <- CirceTypeProvider.DecodingResultTpe
-        } yield {
-          val cases = decoderCasesWithMapping(discriminator, failureTpe)
-          val dscType = discriminator match {
-            case _: Discriminator.StringDsc        => t"String"
-            case _: Discriminator.IntDsc           => t"Int"
-            case Discriminator.EnumDsc(_, enum, _) => enum.typeName
-          }
-          val decoderInit = init"${t"$decoderTpe[$coproductType]"}()"
-          q"""implicit lazy val $decoderName: $decoderTpe[$coproductType] = new $decoderInit {
-            override def apply(c: $hCursorTpe): $resultTpe[$coproductType] =
-              c.downField(${discriminator.fieldName}).as[$dscType].flatMap {
-                ..case $cases
-            }
-        }"""
-        }
+        decoderForCoproductWithMappedDiscriminator(coproduct, discriminator)
+      case Some(discriminator: Discriminator.StringDsc) =>
+        decoderForCoproductWithMappedDiscriminator(coproduct, discriminator)
       case _ =>
+        val coproductType = coproduct.typeName
+        val decoderName = coproduct.asPrefix("Decoder")
         for {
           decoderTpe <- CirceTypeProvider.DecoderTpe
         } yield q"""implicit lazy val $decoderName: $decoderTpe[$coproductType] = List[$decoderTpe[$coproductType]](..${decoderCases(
           coproduct
         )}).reduceLeft(_ or _)"""
     }
+
+  private def decoderForCoproductWithMappedDiscriminator[T](
+      coproduct: Coproduct,
+      discriminator: Discriminator[T]
+  ): IM[Defn.Val] = {
+    val coproductType = coproduct.typeName
+    val decoderName = coproduct.asPrefix("Decoder")
+    val implicitMapping: Map[String, ClassName] =
+      implicitMappingForCoproductDiscriminator(coproduct)
+    for {
+      hCursorTpe <- CirceTypeProvider.HCursorTpe
+      decoderTpe <- CirceTypeProvider.DecoderTpe
+      failureTpe <- CirceTypeProvider.DecodingFailureTpe
+      resultTpe <- CirceTypeProvider.DecodingResultTpe
+    } yield {
+      val cases =
+        decoderCasesWithMapping(discriminator, failureTpe, implicitMapping)
+      val dscType = discriminator match {
+        case _: Discriminator.StringDsc        => t"String"
+        case _: Discriminator.IntDsc           => t"Int"
+        case Discriminator.EnumDsc(_, enum, _) => enum.typeName
+      }
+      val decoderInit = init"${t"$decoderTpe[$coproductType]"}()"
+      q"""implicit lazy val $decoderName: $decoderTpe[$coproductType] = new $decoderInit {
+            override def apply(c: $hCursorTpe): $resultTpe[$coproductType] =
+              c.downField(${discriminator.fieldName}).as[$dscType].flatMap {
+                ..case $cases
+            }
+        }"""
+    }
   }
+
+  private def implicitMappingForCoproductDiscriminator(
+      coproduct: Coproduct
+  ): Map[String, ClassName] =
+    coproduct.childs.toList.map { child: ClassName =>
+      child.typeName.value -> child
+    }.toMap
 
   private def encoderCases(coproduct: Coproduct) =
     coproduct.childs.toList
@@ -116,11 +119,13 @@ private[circe] class CirceCoproductCodecGenerator() {
 
   private def decoderCasesWithMapping(
       discriminator: Discriminator[_],
-      failureTpe: Type.Name
+      failureTpe: Type.Name,
+      implicitMapping: Map[String, ClassName]
   ): List[Case] = {
     val mappedCases = discriminator match {
       case Discriminator.StringDsc(_, mapping) =>
-        mapping.toList.sortBy(_._1).map { case (k, v) =>
+        val mergedMapping = mergeMappings(mapping, implicitMapping)
+        mergedMapping.toList.sortBy(_._1).map { case (k, v) =>
           decoderCaseForString(k, v)
         }
       case Discriminator.IntDsc(_, mapping) =>
@@ -134,6 +139,16 @@ private[circe] class CirceCoproductCodecGenerator() {
     }
     mappedCases :+ decoderOtherwiseCase(failureTpe)
   }
+
+  private def mergeMappings(
+      explicitMapping: Map[String, ClassName],
+      implicitMapping: Map[String, ClassName]
+  ): Map[String, ClassName] =
+    (explicitMapping.toSeq ++ implicitMapping.toSeq)
+      .groupBy(_._2)
+      .values
+      .map(_.head)
+      .toMap
 
   private def decoderCaseForString(discValue: String, child: ClassName) =
     p"case $discValue => Decoder[${child.typeName}].apply(c)"

--- a/core/src/test/resources/api/coproduct/one_of/discriminator_with_enum_mapping.scala
+++ b/core/src/test/resources/api/coproduct/one_of/discriminator_with_enum_mapping.scala
@@ -42,12 +42,12 @@ trait CirceCodecs extends SttpCirceApi {
         Left(DecodingFailure("Unexpected value for coproduct:" + other, Nil))
     })
   }
-  implicit lazy val entityEncoder: Encoder[Entity] = Encoder.instance({
+  implicit lazy val entityEncoder: Encoder[Entity] = Encoder.instance{
     case organization: Organization =>
       Encoder[Organization].apply(organization)
     case person: Person =>
       Encoder[Person].apply(person)
-  })
+  }
 }
 object CirceCodecs extends CirceCodecs
 

--- a/core/src/test/resources/api/coproduct/one_of/discriminator_with_mapping.scala
+++ b/core/src/test/resources/api/coproduct/one_of/discriminator_with_mapping.scala
@@ -28,12 +28,12 @@ trait CirceCodecs extends SttpCirceApi {
         Left(DecodingFailure("Unexpected value for coproduct:" + other, Nil))
     })
   }
-  implicit lazy val entityEncoder: Encoder[Entity] = Encoder.instance({
+  implicit lazy val entityEncoder: Encoder[Entity] = Encoder.instance{
     case organization: Organization =>
       Encoder[Organization].apply(organization)
     case person: Person =>
       Encoder[Person].apply(person)
-  })
+  }
 }
 object CirceCodecs extends CirceCodecs
 

--- a/core/src/test/resources/api/coproduct/one_of/discriminator_with_partial_mapping.scala
+++ b/core/src/test/resources/api/coproduct/one_of/discriminator_with_partial_mapping.scala
@@ -28,12 +28,12 @@ trait CirceCodecs extends SttpCirceApi {
         Left(DecodingFailure("Unexpected value for coproduct:" + other, Nil))
     })
   }
-  implicit lazy val entityEncoder: Encoder[Entity] = Encoder.instance({
+  implicit lazy val entityEncoder: Encoder[Entity] = Encoder.instance{
     case organization: Organization =>
       Encoder[Organization].apply(organization)
     case person: Person =>
       Encoder[Person].apply(person)
-  })
+  }
 }
 object CirceCodecs extends CirceCodecs
 

--- a/core/src/test/resources/api/coproduct/one_of/discriminator_with_partial_mapping.scala
+++ b/core/src/test/resources/api/coproduct/one_of/discriminator_with_partial_mapping.scala
@@ -20,10 +20,10 @@ trait CirceCodecs extends SttpCirceApi {
     Encoder.forProduct2("name", "age")(p => (p.name, p.age))
   implicit lazy val entityDecoder: Decoder[Entity] = new Decoder[Entity]() {
     override def apply(c: HCursor): Result[Entity] = c.downField("name").as[String].flatMap({
+      case "Organization" =>
+        Decoder[Organization].apply(c)
       case "john" =>
         Decoder[Person].apply(c)
-      case "sml" =>
-        Decoder[Organization].apply(c)
       case other =>
         Left(DecodingFailure("Unexpected value for coproduct:" + other, Nil))
     })

--- a/core/src/test/resources/api/coproduct/one_of/discriminator_with_partial_mapping.yaml
+++ b/core/src/test/resources/api/coproduct/one_of/discriminator_with_partial_mapping.yaml
@@ -1,0 +1,42 @@
+openapi: 3.0.3
+info:
+  title: Fruits
+  version: "1.0"
+paths:
+  /:
+    get:
+      operationId: getRoot
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Entity"
+components:
+  schemas:
+    Entity:
+      oneOf:
+        - $ref: "#/components/schemas/Person"
+        - $ref: "#/components/schemas/Organization"
+      discriminator:
+        propertyName: name
+        mapping:
+          john: "#/components/schemas/Person"
+    Person:
+      required:
+        - name
+        - age
+      type: object
+      properties:
+        name:
+          type: string
+        age:
+          type: integer
+    Organization:
+      required:
+        - name
+      type: object
+      properties:
+        name:
+          type: string

--- a/core/src/test/resources/api/coproduct/one_of/string_discriminator.scala
+++ b/core/src/test/resources/api/coproduct/one_of/string_discriminator.scala
@@ -28,12 +28,12 @@ trait CirceCodecs extends SttpCirceApi {
         Left(DecodingFailure("Unexpected value for coproduct:" + other, Nil))
     })
   }
-  implicit lazy val entityEncoder: Encoder[Entity] = Encoder.instance({
+  implicit lazy val entityEncoder: Encoder[Entity] = Encoder.instance{
     case organization: Organization =>
       Encoder[Organization].apply(organization)
     case person: Person =>
       Encoder[Person].apply(person)
-  })
+  }
 }
 object CirceCodecs extends CirceCodecs
 
@@ -48,9 +48,9 @@ class DefaultApi(baseUrl: String, circeCodecs: CirceCodecs = CirceCodecs) {
     .get(uri"$baseUrl")
     .response(
       fromMetadata(
-        asJson[Entity].getRight, 
+        asJson[Entity].getRight,
         ConditionalResponseAs(
-          _.code == StatusCode.unsafeApply(200), 
+          _.code == StatusCode.unsafeApply(200),
           asJson[Entity].getRight
         )
       )

--- a/core/src/test/resources/api/coproduct/one_of/string_discriminator.scala
+++ b/core/src/test/resources/api/coproduct/one_of/string_discriminator.scala
@@ -10,13 +10,13 @@ import _root_.io.circe.Decoder.Result
 import _root_.sttp.client3.circe.SttpCirceApi
 
 trait CirceCodecs extends SttpCirceApi {
-  implicit lazy val organizationDecoder: Decoder[Organization] = 
+  implicit lazy val organizationDecoder: Decoder[Organization] =
     Decoder.forProduct1("name")(Organization.apply)
-  implicit lazy val organizationEncoder: Encoder[Organization] = 
+  implicit lazy val organizationEncoder: Encoder[Organization] =
     Encoder.forProduct1("name")(p => p.name)
-  implicit lazy val personDecoder: Decoder[Person] = 
+  implicit lazy val personDecoder: Decoder[Person] =
     Decoder.forProduct2("name", "age")(Person.apply)
-  implicit lazy val personEncoder: Encoder[Person] = 
+  implicit lazy val personEncoder: Encoder[Person] =
     Encoder.forProduct2("name", "age")(p => (p.name, p.age))
   implicit lazy val entityDecoder: Decoder[Entity] = new Decoder[Entity]() {
     override def apply(c: HCursor): Result[Entity] = c.downField("name").as[String].flatMap({

--- a/core/src/test/scala/io/github/ghostbuster91/sttp/client3/GeneratorTest.scala
+++ b/core/src/test/scala/io/github/ghostbuster91/sttp/client3/GeneratorTest.scala
@@ -76,6 +76,7 @@ object GeneratorTest extends TestSuite {
         "string_discriminator" - test()
         "int_discriminator" - test()
         "discriminator_with_mapping" - test()
+        "discriminator_with_partial_mapping" - test()
         // Following case is actually invalid because there is no way to create discriminator mapping using empty value as a key
         //"optional_discriminator" - test()
         "discriminator_enum" - test()


### PR DESCRIPTION
The OpenApi spec allows implicit and partial mapping in the [Discriminator object](https://swagger.io/specification/#discriminator-object). Currently the Decoder for a Coproduct with a Discriminator without mapping is not using the Discriminator property to map to the right type, which might cause decoding issues. This PR aims to fix this issue for discriminator properties of type String.