### PR TITLE
Adds support for returning the same error across multiple status codes

### DIFF
--- a/core/src/main/scala/io/github/ghostbuster91/sttp/client3/openapi/OpenApiCoproductGenerator.scala
+++ b/core/src/main/scala/io/github/ghostbuster91/sttp/client3/openapi/OpenApiCoproductGenerator.scala
@@ -17,7 +17,7 @@ object OpenApiCoproductGenerator {
       collectCandidates(openApi, childToParent, collectSuccessResponses)
     val newCoproducts = errorsWithoutCommonParent
       .map(kv =>
-        createCoproduct(kv._1, kv._2, "GenericError")
+        createCoproduct(kv._1, kv._2.distinct, "GenericError")
       ) ++ successesWithoutCommonParent
       .map(kv => createCoproduct(kv._1, kv._2, "GenericSuccess"))
 

--- a/core/src/test/resources/api/errors/single_error_for_multiple_status_codes.scala
+++ b/core/src/test/resources/api/errors/single_error_for_multiple_status_codes.scala
@@ -1,0 +1,52 @@
+package io.github.ghostbuster91.sttp.client3.example
+
+import _root_.sttp.client3._
+import _root_.sttp.model._
+import _root_.io.circe.{Error => CirceError}
+import _root_.io.circe.Decoder
+import _root_.io.circe.Encoder
+import _root_.sttp.client3.circe.SttpCirceApi
+
+trait CirceCodecs extends SttpCirceApi {
+  implicit lazy val errorModelDecoder: Decoder[ErrorModel] =
+    Decoder.forProduct1("msg")(ErrorModel.apply)
+  implicit lazy val errorModelEncoder: Encoder[ErrorModel] =
+    Encoder.forProduct1("msg")(p => p.msg)
+  implicit lazy val updatePersonGenericErrorDecoder
+      : Decoder[UpdatePersonGenericError] =
+    List[Decoder[UpdatePersonGenericError]](
+      Decoder[ErrorModel].asInstanceOf[Decoder[UpdatePersonGenericError]]
+    ).reduceLeft(_ or _)
+  implicit lazy val updatePersonGenericErrorEncoder
+      : Encoder[UpdatePersonGenericError] = Encoder.instance {
+    case errorModel: ErrorModel =>
+      Encoder[ErrorModel].apply(errorModel)
+  }
+}
+object CirceCodecs extends CirceCodecs
+
+sealed trait UpdatePersonGenericError
+case class ErrorModel(msg: String) extends UpdatePersonGenericError()
+
+class DefaultApi(baseUrl: String, circeCodecs: CirceCodecs = CirceCodecs) {
+  import circeCodecs._
+
+  def updatePerson(): Request[
+    Either[ResponseException[UpdatePersonGenericError, CirceError], Unit],
+    Any
+  ] = basicRequest
+    .put(uri"$baseUrl/person")
+    .response(
+      fromMetadata(
+        asJsonEither[UpdatePersonGenericError, Unit],
+        ConditionalResponseAs(
+          _.code == StatusCode.unsafeApply(400),
+          asJsonEither[ErrorModel, Unit]
+        ),
+        ConditionalResponseAs(
+          _.code == StatusCode.unsafeApply(401),
+          asJsonEither[ErrorModel, Unit]
+        )
+      )
+    )
+}

--- a/core/src/test/resources/api/errors/single_error_for_multiple_status_codes.yaml
+++ b/core/src/test/resources/api/errors/single_error_for_multiple_status_codes.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.2
+info:
+  title: Single Error
+  version: "1.0"
+paths:
+  /person:
+    put:
+      summary: Update an existing person
+      description: Update an existing person by Id
+      operationId: updatePerson
+      responses:
+        "400":
+          description: Returns a 400
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+        "401":
+          description: Returns a 401
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+components:
+  schemas:
+    ErrorModel:
+      required:
+        - msg
+      type: object
+      properties:
+        msg:
+          type: string

--- a/core/src/test/scala/io/github/ghostbuster91/sttp/client3/GeneratorTest.scala
+++ b/core/src/test/scala/io/github/ghostbuster91/sttp/client3/GeneratorTest.scala
@@ -119,6 +119,7 @@ object GeneratorTest extends TestSuite {
       "product" - test(CodegenConfig(handleErrors = true))
       "multiple_errors" - test(CodegenConfig(handleErrors = true))
       "multiple_errors_with_parent" - test(CodegenConfig(handleErrors = true))
+      "single_error_for_multiple_status_codes" - test(CodegenConfig(handleErrors = true))
     }
     "multiple_success" - {
       "separate_products" - test()


### PR DESCRIPTION
I noticed that there's an issue when returning the same error for multiple status codes like below:

```yaml
openapi: 3.0.2
info:
  title: Single Error
  version: "1.0"
paths:
  /person:
    put:
      summary: Update an existing person
      description: Update an existing person by Id
      operationId: updatePerson
      responses:
        "400":
          description: Returns a 400
          content:
            application/json:
              schema:
                $ref: "#/components/schemas/ErrorModel"
        "401":
          description: Returns a 401
          content:
            application/json:
              schema:
                $ref: "#/components/schemas/ErrorModel"
components:
  schemas:
    ErrorModel:
      required:
        - msg
      type: object
      properties:
        msg:
          type: string
```

This will not compile, as it will try to extend the `ErrorModel` twice:

```scala
sealed trait GetRootGenericError
case class ErrorMessage(message: String)
    extends GetRootGenericError()
    with GetRootGenericError()
```

This PR fixes this issue by creating the coproducts based on the **distinct** error responses.